### PR TITLE
Updated waggle for monk stamina

### DIFF
--- a/scripts/waggle.lic
+++ b/scripts/waggle.lic
@@ -1,44 +1,44 @@
-=begin
+#
+#   waggle.lic:  Spellup script for yourself and others.  This script is a rewrite of ultrawaggle from SpiffyJr, which is a heavily modified version of spellup from Shaelun and Blueland.
+#     ;waggle help
+#
+#     maintainer: elanthia-online
+#   contributers: Tillmen
+#           game: Gemstone
+#           tags: magic, utility
+#       required: Lich >= 4.4.6
+#        version: 0.18.1
+#         source: https://github.com/elanthia-online/gtk3-scripts
+#
+#   Version Control:
+#     Major_change.feature_addition.bugfix
+#
+#   0.18.1 (2021-08-21):
+#     Updated to account for Monk and Feat mental acuity
+#   0.17.0 (2021-08-12):
+#     updated with new SPELL ACTIVE format
+#     updated header information for standardization
+#   0.16 (2020-08-21):
+#     added squelching of spell active output (using quiet_command from Lostranger scripts)
+#   0.15 (2020-08-20):
+#     hacked in using new SPELL ACTIVE <target> functionality
+#   0.14 (2019-05-11):
+#     fix --reserve-mana (austin-j)
+#   0.13 (2019-03-03):
+#     set refreshable_min value from CLI if present (sandersch)
+#   0.12 (2018-04-20):
+#     fix --refreshable-min command line option
+#
 
-  waggle.lic:  Spellup script for yourself and others.  This script is a rewrite of ultrawaggle from SpiffyJr, which is a heavily modified version of spellup from Shaelun and Blueland.
-    ;waggle help
-
-    maintainer: elanthia-online
-  contributers: Tillmen
-          game: Gemstone
-          tags: magic, utility
-      required: Lich >= 4.4.6
-       version: 0.17.0
-        source: https://github.com/elanthia-online/gtk3-scripts
-
-  Version Control:
-    Major_change.feature_addition.bugfix
-
-  0.17.0 (2021-08-12):
-    updated with new SPELL ACTIVE format
-    updated header information for standardization
-  0.16 (2020-08-21):
-    added squelching of spell active output (using quiet_command from Lostranger scripts)
-  0.15 (2020-08-20):
-    hacked in using new SPELL ACTIVE <target> functionality
-  0.14 (2019-05-11):
-    fix --reserve-mana (austin-j)
-  0.13 (2019-03-03):
-    set refreshable_min value from CLI if present (sandersch)
-  0.12 (2018-04-20):
-    fix --refreshable-min command line option
-
-=end
-
-# fixme: option to cast high level spells first
+# FIXME: option to cast high level spells first
 # fixme: armor specialization
 # fixme: option to not cast low duration spells on others
 
 start_at          = CharSettings['start_at']          || 180
 stop_at           = CharSettings['stop_at']           || 180
-stop_at           = [stop_at,250].min
+stop_at           = [stop_at, 250].min
 stop_before       = CharSettings['stop_before']       || 250
-refreshable_min   = CharSettings['unstackable_min']   ||  15
+refreshable_min   = CharSettings['unstackable_min']   || 15
 use_multicast     = CharSettings['use_multicast']
 use_multicast     = true if use_multicast.nil?
 use_wracking      = CharSettings['use_wracking']      || false
@@ -50,1235 +50,1242 @@ skip_jerks        = CharSettings['skip_jerks']        || false
 skip_short_spells = CharSettings['skip_short_spells'] || false
 reserve_mana      = CharSettings['reserve_mana']      || 0
 retribution_spell = CharSettings['retribution_spell']
-cast_list         = CharSettings['cast_list']         || [ 101, 102, 103, 107, 115, 120, 202, 211, 215, 219, 303, 307, 310, 313, 401, 406, 414, 425, 430, 503, 507, 508, 509, 513, 520, 601, 602, 606, 613, 617, 618, 625, 640, 712, 905, 911, 913, 920, 1109, 1119, 1125, 1130, 1601, 1603, 1606, 1610, 1611, 1612, 1616 ]
+cast_list         = CharSettings['cast_list']         || [101, 102, 103, 107, 115, 120, 202, 211, 215, 219, 303, 307, 310, 313, 401, 406, 414, 425, 430, 503, 507, 508, 509, 513, 520, 601, 602, 606, 613, 617, 618, 625, 640, 712, 905, 911, 913, 920, 1109, 1119, 1125, 1130, 1601, 1603, 1606, 1610, 1611, 1612, 1616]
 did_something     = false
 fix_setting       = { 'on' => true, 'off' => false }
 short_spell_time  = 3
 
 if setting = script.vars.find { |var| var =~ /^\-\-start[_\-]at=[0-9]+$/ }
-   start_at = setting.slice(/[0-9]+/).to_i
-   script.vars.delete(setting)
+  start_at = setting.slice(/[0-9]+/).to_i
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-stop[_\-]at=[0-9]+$/ }
-   stop_at = [setting.slice(/[0-9]+/).to_i,250].min
-   script.vars.delete(setting)
+  stop_at = [setting.slice(/[0-9]+/).to_i, 250].min
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-stop[_\-]before=[0-9]+$/ }
-   stop_before = setting.slice(/[0-9]+/).to_i
-   script.vars.delete(setting)
+  stop_before = setting.slice(/[0-9]+/).to_i
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-(?:unstackable|refreshable)[_\-]min=[0-9]+$/ }
-   refreshable_min = setting.slice(/[0-9]+/).to_i
-   script.vars.delete(setting)
+  refreshable_min = setting.slice(/[0-9]+/).to_i
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-cast[_\-]list=[0-9,]+$/ }
-   cast_list = setting.slice(/[0-9,]+/).split(',').collect { |num| num.to_i }
-   script.vars.delete(setting)
+  cast_list = setting.slice(/[0-9,]+/).split(',').collect { |num| num.to_i }
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-use[_\-]multicast=(?:on|off)$/ }
-   use_multicast = fix_setting[setting.slice(/on|off/)]
-   script.vars.delete(setting)
+  use_multicast = fix_setting[setting.slice(/on|off/)]
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-use[_\-]wracking=(?:on|off)$/ }
-   use_wracking = fix_setting[setting.slice(/on|off/)]
-   script.vars.delete(setting)
+  use_wracking = fix_setting[setting.slice(/on|off/)]
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-wander[_\-]to[_\-]wrack=(?:on|off)$/ }
-   wander_to_wrack = fix_setting[setting.slice(/on|off/)]
-   script.vars.delete(setting)
+  wander_to_wrack = fix_setting[setting.slice(/on|off/)]
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-use[_\-]power=(?:on|off)$/ }
-   use_power = fix_setting[setting.slice(/on|off/)]
-   script.vars.delete(setting)
+  use_power = fix_setting[setting.slice(/on|off/)]
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-use[_\-]mana=(?:on|off)$/ }
-   use_mana = fix_setting[setting.slice(/on|off/)]
-   script.vars.delete(setting)
+  use_mana = fix_setting[setting.slice(/on|off/)]
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-use[_\-]concentration=(?:on|off)$/ }
-   use_concentration = fix_setting[setting.slice(/on|off/)]
-   script.vars.delete(setting)
+  use_concentration = fix_setting[setting.slice(/on|off/)]
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-skip[_\-]jerks=(?:on|off)$/ }
-   skip_jerks = fix_setting[setting.slice(/on|off/)]
-   script.vars.delete(setting)
+  skip_jerks = fix_setting[setting.slice(/on|off/)]
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-skip[_\-]short(?:[_\-]spells)?=(?:on|off)$/ }
-   skip_short_spells = fix_setting[setting.slice(/on|off/)]
-   script.vars.delete(setting)
+  skip_short_spells = fix_setting[setting.slice(/on|off/)]
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-retribution[_\-]spell=(?:[0-9]+|off)$/ }
-   if setting =~ /^\-\-retribution[_\-]spell=off$/
-      retribution_spell = nil
-   elsif setting =~ /^\-\-retribution[_\-]spell=([0-9]+)$/
-      retribution_spell = $1.to_i
-   end
-   script.vars.delete(setting)
+  if setting =~ /^\-\-retribution[_\-]spell=off$/
+    retribution_spell = nil
+  elsif setting =~ /^\-\-retribution[_\-]spell=([0-9]+)$/
+    retribution_spell = $1.to_i
+  end
+  script.vars.delete(setting)
 end
 if setting = script.vars.find { |var| var =~ /^\-\-reserve[_\-]mana=([0-9]+)$/ }
-   reserve_mana = $1.to_i
-   script.vars.delete(setting)
+  reserve_mana = $1.to_i
+  script.vars.delete(setting)
 end
 if script.vars.include?('--save')
-   CharSettings['use_wracking']      = use_wracking
-   CharSettings['use_multicast']     = use_multicast
-   CharSettings['wander_to_wrack']   = wander_to_wrack
-   CharSettings['use_power']         = use_power
-   CharSettings['use_mana']          = use_mana
-   CharSettings['use_concentration'] = use_concentration
-   CharSettings['skip_jerks']        = skip_jerks
-   CharSettings['skip_short_spells'] = skip_short_spells
-   CharSettings['start_at']          = start_at
-   CharSettings['stop_at']           = stop_at
-   CharSettings['stop_before']       = stop_before
-   CharSettings['unstackable_min']   = refreshable_min
-   CharSettings['retribution_spell'] = retribution_spell
-   CharSettings['reserve_mana']      = reserve_mana
-   CharSettings['cast_list']         = cast_list
-   exit
+  CharSettings['use_wracking'] = use_wracking
+  CharSettings['use_multicast']     = use_multicast
+  CharSettings['wander_to_wrack']   = wander_to_wrack
+  CharSettings['use_power']         = use_power
+  CharSettings['use_mana']          = use_mana
+  CharSettings['use_concentration'] = use_concentration
+  CharSettings['skip_jerks']        = skip_jerks
+  CharSettings['skip_short_spells'] = skip_short_spells
+  CharSettings['start_at']          = start_at
+  CharSettings['stop_at']           = stop_at
+  CharSettings['stop_before']       = stop_before
+  CharSettings['unstackable_min']   = refreshable_min
+  CharSettings['retribution_spell'] = retribution_spell
+  CharSettings['reserve_mana']      = reserve_mana
+  CharSettings['cast_list']         = cast_list
+  exit
 end
 
-known_spells      = Spells.known.collect { |spell| spell.num }
+known_spells = Spells.known.collect { |spell| spell.num }
 cast_list.delete_if { |spell| !(known_spells.include?(spell) and Spell[spell].time_per > 0) }
-list_mode         = false
+list_mode = false
 
 if script.vars.empty?
-   target_list = [ Char.name ]
+  target_list = [Char.name]
 elsif script.vars[1].downcase == 'help'
-   respond
-   respond 'Usage:'
-   respond "   #{$clean_lich_char}#{script.name} help                        show this message"
-   respond "   #{$clean_lich_char}#{script.name} setup                       show setup window"
-   respond "   #{$clean_lich_char}#{script.name} list                        show current settings"
-   respond
-   respond "   #{$clean_lich_char}#{script.name} add [spell#]                add one or more spells to the cast list"
-   respond "   #{$clean_lich_char}#{script.name} delete [spell#]             delete one or more spells from the cast list"
-   respond
-   respond "   #{$clean_lich_char}#{script.name} start-at [minutes]          stackable spells will be cast if they have less than (start_at) minutes remaining"
-   respond "   #{$clean_lich_char}#{script.name} stop-at [minutes]             when the script starts, and will be cast while the time left is less than"
-   respond "   #{$clean_lich_char}#{script.name} stop-before [minutes]         (stop_at) and the time left after another cast would be less than (stop before)"
-   respond
-   respond "   #{$clean_lich_char}#{script.name} refreshable-min [minutes]   minimum time for non-stacking spells"
-   respond
-   respond "   #{$clean_lich_char}#{script.name} multicast [on/off]          use multicast"
-   respond "   #{$clean_lich_char}#{script.name} wracking [on/off]           use sign of wracking when out of mana"
-   respond "   #{$clean_lich_char}#{script.name} wander [on/off]             wander up to 20 rooms to find an empty room to wrack in and return"
-   respond "   #{$clean_lich_char}#{script.name} power [on/off]              use sigil of power when out of mana"
-   respond "   #{$clean_lich_char}#{script.name} concentration [on/off]      use sigil of concentration when out of mana"
-   respond "   #{$clean_lich_char}#{script.name} mana [on/off]               use symbol of mana when out of mana"
-   respond "   #{$clean_lich_char}#{script.name} skip-jerks [on/off]         skip targets that don't share their current spell durations"
-   respond "   #{$clean_lich_char}#{script.name} skip-short-spells [on/off]  don't cast spells with a duration less than #{short_spell_time} minutes on others"
-   respond "   #{$clean_lich_char}#{script.name} retribution-spell [#|none]  spell number for chant retribution after casting cloak of shadows"
-   respond
-   respond "   #{$clean_lich_char}#{script.name}                             spell yourself up"
-   respond "   #{$clean_lich_char}#{script.name} [name1] [name2] ...         spell up the given people (may include your own name)"
-   respond "   #{$clean_lich_char}#{script.name} info                        show what will be cast and how much it will cost"
-   respond "   #{$clean_lich_char}#{script.name} info [name1] [name2]        ''"
-   respond
-   respond "   Any or all saved options can be overridden on the command line without being saved using the following syntax:"
-   respond
-   respond "   #{$clean_lich_char}#{script.name} --cast-list=401,406,503 --start-at=60 --stop-at=120 --stop-before=250 --refreshable-min=10 --use-wracking=on --wander-to-wrack=on --use-power=off --use-concentration=off --use-mana=off --skip-jerks=on --skip-short-spells=on --retribution-spell=717 Jim Joe Bob"
-   respond
-   exit
+  respond
+  respond 'Usage:'
+  respond "   #{$clean_lich_char}#{script.name} help                        show this message"
+  respond "   #{$clean_lich_char}#{script.name} setup                       show setup window"
+  respond "   #{$clean_lich_char}#{script.name} list                        show current settings"
+  respond
+  respond "   #{$clean_lich_char}#{script.name} add [spell#]                add one or more spells to the cast list"
+  respond "   #{$clean_lich_char}#{script.name} delete [spell#]             delete one or more spells from the cast list"
+  respond
+  respond "   #{$clean_lich_char}#{script.name} start-at [minutes]          stackable spells will be cast if they have less than (start_at) minutes remaining"
+  respond "   #{$clean_lich_char}#{script.name} stop-at [minutes]             when the script starts, and will be cast while the time left is less than"
+  respond "   #{$clean_lich_char}#{script.name} stop-before [minutes]         (stop_at) and the time left after another cast would be less than (stop before)"
+  respond
+  respond "   #{$clean_lich_char}#{script.name} refreshable-min [minutes]   minimum time for non-stacking spells"
+  respond
+  respond "   #{$clean_lich_char}#{script.name} multicast [on/off]          use multicast"
+  respond "   #{$clean_lich_char}#{script.name} wracking [on/off]           use sign of wracking when out of mana"
+  respond "   #{$clean_lich_char}#{script.name} wander [on/off]             wander up to 20 rooms to find an empty room to wrack in and return"
+  respond "   #{$clean_lich_char}#{script.name} power [on/off]              use sigil of power when out of mana"
+  respond "   #{$clean_lich_char}#{script.name} concentration [on/off]      use sigil of concentration when out of mana"
+  respond "   #{$clean_lich_char}#{script.name} mana [on/off]               use symbol of mana when out of mana"
+  respond "   #{$clean_lich_char}#{script.name} skip-jerks [on/off]         skip targets that don't share their current spell durations"
+  respond "   #{$clean_lich_char}#{script.name} skip-short-spells [on/off]  don't cast spells with a duration less than #{short_spell_time} minutes on others"
+  respond "   #{$clean_lich_char}#{script.name} retribution-spell [#|none]  spell number for chant retribution after casting cloak of shadows"
+  respond
+  respond "   #{$clean_lich_char}#{script.name}                             spell yourself up"
+  respond "   #{$clean_lich_char}#{script.name} [name1] [name2] ...         spell up the given people (may include your own name)"
+  respond "   #{$clean_lich_char}#{script.name} info                        show what will be cast and how much it will cost"
+  respond "   #{$clean_lich_char}#{script.name} info [name1] [name2]        ''"
+  respond
+  respond "   Any or all saved options can be overridden on the command line without being saved using the following syntax:"
+  respond
+  respond "   #{$clean_lich_char}#{script.name} --cast-list=401,406,503 --start-at=60 --stop-at=120 --stop-before=250 --refreshable-min=10 --use-wracking=on --wander-to-wrack=on --use-power=off --use-concentration=off --use-mana=off --skip-jerks=on --skip-short-spells=on --retribution-spell=717 Jim Joe Bob"
+  respond
+  exit
 elsif script.vars[1] =~ /^setup$|^options$/i
-   if HAVE_GTK and defined?(Gtk.queue)
-      window = window_action = nil
-      window_width  = CharSettings['window_width'] || 445
-      window_height = CharSettings['window_height'] || 490
-      Gtk.queue {
-         nocast_label = Gtk::Label.new('Spells not to Cast')
-         cast_label = Gtk::Label.new('Spells to Cast')
+  if HAVE_GTK && defined?(Gtk.queue)
+    window = window_action = nil
+    window_width  = CharSettings['window_width'] || 445
+    window_height = CharSettings['window_height'] || 490
+    Gtk.queue do
+      nocast_label = Gtk::Label.new('Spells not to Cast')
+      cast_label = Gtk::Label.new('Spells to Cast')
 
-         label_box = Gtk::Box.new(:horizontal, 5)
-         label_box.pack_start(nocast_label, :expand => false, :fill => false, :padding => 0)
-         label_box.pack_start(cast_label, :expand => false, :fill => false, :padding => 0)
+      label_box = Gtk::Box.new(:horizontal, 5)
+      label_box.pack_start(nocast_label, expand: true, fill: false, padding: 0)
+      label_box.pack_start(cast_label, expand: true, fill: false, padding: 0)
 
-         renderer = Gtk::CellRendererText.new
-         renderer.background = 'white'
+      renderer = Gtk::CellRendererText.new
 
-         nocast_ls = Gtk::ListStore.new(String, String)
-         nocast_ls.set_sort_column_id(0, :ascending)
-         nocast_tv = Gtk::TreeView.new(nocast_ls)
-         nocast_tv.headers_visible = false
-         nocast_tv.height_request = 150
-         nocast_tv.append_column(Gtk::TreeViewColumn.new('', renderer, :text => 0, :background_set => 2))
-         nocast_tv.append_column(Gtk::TreeViewColumn.new('', renderer, :text => 1, :background_set => 2))
-         nocast_sw = Gtk::ScrolledWindow.new
-         nocast_sw.set_policy(:automatic, :always)
-         nocast_sw.add(nocast_tv)
+      nocast_ls = Gtk::ListStore.new(String, String)
+      nocast_ls.set_sort_column_id(0, :ascending)
+      nocast_tv = Gtk::TreeView.new(nocast_ls)
+      nocast_tv.headers_visible = false
+      nocast_tv.height_request = 150
+      nocast_tv.append_column(Gtk::TreeViewColumn.new('', renderer, text: 0))
+      nocast_tv.append_column(Gtk::TreeViewColumn.new('', renderer, text: 1))
+      nocast_sw = Gtk::ScrolledWindow.new
+      nocast_sw.set_policy(:automatic, :always)
+      nocast_sw.add(nocast_tv)
 
-         cast_ls = Gtk::ListStore.new(String, String)
-         cast_ls.set_sort_column_id(0, :ascending)
-         cast_tv = Gtk::TreeView.new(cast_ls)
-         cast_tv.headers_visible = false
-         cast_tv.height_request = 150
-         cast_tv.append_column(Gtk::TreeViewColumn.new('', renderer, :text => 0, :background_set => 2))
-         cast_tv.append_column(Gtk::TreeViewColumn.new('', renderer, :text => 1, :background_set => 2))
-         cast_sw = Gtk::ScrolledWindow.new
-         cast_sw.set_policy(:automatic, :always)
-         cast_sw.add(cast_tv)
+      cast_ls = Gtk::ListStore.new(String, String)
+      cast_ls.set_sort_column_id(0, :ascending)
+      cast_tv = Gtk::TreeView.new(cast_ls)
+      cast_tv.headers_visible = false
+      cast_tv.height_request = 150
+      cast_tv.append_column(Gtk::TreeViewColumn.new('', renderer, text: 0))
+      cast_tv.append_column(Gtk::TreeViewColumn.new('', renderer, text: 1))
+      cast_sw = Gtk::ScrolledWindow.new
+      cast_sw.set_policy(:automatic, :always)
+      cast_sw.add(cast_tv)
 
-         tree_box = Gtk::Box.new(:horizontal, 5)
-         tree_box.pack_start(nocast_sw, :expand => true, :fill => true, :padding => 0)
-         tree_box.pack_start(cast_sw, :expand => true, :fill => true, :padding => 0)
+      tree_box = Gtk::Box.new(:horizontal, 5)
+      tree_box.pack_start(nocast_sw, expand: true, fill: true, padding: 0)
+      tree_box.pack_start(cast_sw, expand: true, fill: true, padding: 0)
 
-         start_at_label = Gtk::Label.new('start casting if below:')
-         start_at_entry = Gtk::Entry.new
-         start_at_entry.text = start_at.to_s
-         start_at_entry.width_request = 50
-         stop_at_label = Gtk::Label.new('stop casting at:')
-         stop_at_entry = Gtk::Entry.new
-         stop_at_entry.text = stop_at.to_s
-         stop_at_entry.width_request = 50
-         stop_before_label = Gtk::Label.new("don't cast over:")
-         stop_before_entry = Gtk::Entry.new
-         stop_before_entry.text = stop_before.to_s
-         stop_before_entry.width_request = 50
+      start_at_label = Gtk::Label.new('start casting if below:')
+      start_at_entry = Gtk::Entry.new
+      start_at_entry.text = start_at.to_s
+      start_at_entry.width_request = 50
+      stop_at_label = Gtk::Label.new('stop casting at:')
+      stop_at_entry = Gtk::Entry.new
+      stop_at_entry.text = stop_at.to_s
+      stop_at_entry.width_request = 50
+      stop_before_label = Gtk::Label.new("don't cast over:")
+      stop_before_entry = Gtk::Entry.new
+      stop_before_entry.text = stop_before.to_s
+      stop_before_entry.width_request = 50
 
-         stack_box = Gtk::Box.new(:vertical, 0)
+      stack_box = Gtk::Box.new(:vertical, 0)
 
-         temp_box = Gtk::Box.new(:horizontal, 0)
-         temp_box.pack_end(start_at_entry, :expand => false, :fill => false, :padding => 5)
-         temp_box.pack_end(start_at_label, :expand => false, :fill => false, :padding => 5)
-         stack_box.pack_start(temp_box, :expand => false, :fill => false, :padding => 5)
+      temp_box = Gtk::Box.new(:horizontal, 0)
+      temp_box.pack_end(start_at_entry, expand: false, fill: false, padding: 5)
+      temp_box.pack_end(start_at_label, expand: false, fill: false, padding: 5)
+      stack_box.pack_start(temp_box, expand: false, fill: false, padding: 5)
 
-         temp_box = Gtk::Box.new(:horizontal, 0)
-         temp_box.pack_end(stop_at_entry, :expand => false, :fill => false, :padding => 5)
-         temp_box.pack_end(stop_at_label, :expand => false, :fill => false, :padding => 5)
-         stack_box.pack_start(temp_box, :expand => false, :fill => false, :padding => 5)
+      temp_box = Gtk::Box.new(:horizontal, 0)
+      temp_box.pack_end(stop_at_entry, expand: false, fill: false, padding: 5)
+      temp_box.pack_end(stop_at_label, expand: false, fill: false, padding: 5)
+      stack_box.pack_start(temp_box, expand: false, fill: false, padding: 5)
 
-         temp_box = Gtk::Box.new(:horizontal, 0)
-         temp_box.pack_end(stop_before_entry, :expand => false, :fill => false, :padding => 5)
-         temp_box.pack_end(stop_before_label, :expand => false, :fill => false, :padding => 5)
-         stack_box.pack_start(temp_box, :expand => false, :fill => false, :padding => 5)
+      temp_box = Gtk::Box.new(:horizontal, 0)
+      temp_box.pack_end(stop_before_entry, expand: false, fill: false, padding: 5)
+      temp_box.pack_end(stop_before_label, expand: false, fill: false, padding: 5)
+      stack_box.pack_start(temp_box, expand: false, fill: false, padding: 5)
 
-         stack_box_spacer = Gtk::Box.new(:vertical)
-         stack_box_spacer.pack_start(stack_box, :expand => false, :fill => false, :padding => 4)
+      stack_box_spacer = Gtk::Box.new(:vertical)
+      stack_box_spacer.pack_start(stack_box, expand: false, fill: false, padding: 4)
 
-         stack_frame = Gtk::Frame.new('Stackable Spells')
-         stack_frame.add(stack_box_spacer)
+      stack_frame = Gtk::Frame.new('Stackable Spells')
+      stack_frame.add(stack_box_spacer)
 
-         nonstack_min_label = Gtk::Label.new('   Minimum:')
-         nonstack_min_entry = Gtk::Entry.new
-         nonstack_min_entry.text = refreshable_min.to_s
-         nonstack_min_entry.width_request = 50
+      nonstack_min_label = Gtk::Label.new('   Minimum:')
+      nonstack_min_entry = Gtk::Entry.new
+      nonstack_min_entry.text = refreshable_min.to_s
+      nonstack_min_entry.width_request = 50
 
-         nonstack_box = Gtk::Box.new(:horizontal, 0)
-         nonstack_box.pack_end(nonstack_min_entry, :expand => false, :fill => false, :padding => 4)
-         nonstack_box.pack_end(nonstack_min_label, :expand => false, :fill => false, :padding => 4)
-         nonstack_box_spacer = Gtk::Box.new(:vertical)
-         nonstack_box_spacer.pack_start(nonstack_box, :expand => false, :fill => false, :padding => 4)
-         nonstack_frame = Gtk::Frame.new('Non-stackable Spells')
-         nonstack_frame.add(nonstack_box_spacer)
+      nonstack_box = Gtk::Box.new(:horizontal, 0)
+      nonstack_box.pack_end(nonstack_min_entry, expand: false, fill: false, padding: 4)
+      nonstack_box.pack_end(nonstack_min_label, expand: false, fill: false, padding: 4)
+      nonstack_box_spacer = Gtk::Box.new(:vertical)
+      nonstack_box_spacer.pack_start(nonstack_box, expand: false, fill: false, padding: 4)
+      nonstack_frame = Gtk::Frame.new('Non-stackable Spells')
+      nonstack_frame.add(nonstack_box_spacer)
 
-         other_option_box = Gtk::Box.new(:vertical, 0)
+      other_option_box = Gtk::Box.new(:vertical, 0)
 
-         retribution_spell_label = Gtk::Label.new('retribution spell:')
-         retribution_spell_entry = Gtk::Entry.new
-         retribution_spell_entry.text = retribution_spell.to_s
-         retribution_spell_entry.width_request = 50
-         temp_box = Gtk::Box.new(:horizontal, 0)
-         temp_box.pack_end(retribution_spell_entry, :expand => false, :fill => false, :padding => 5)
-         temp_box.pack_end(retribution_spell_label, :expand => false, :fill => false, :padding => 5)
-         other_option_box.pack_start(temp_box, :expand => false, :fill => false, :padding => 4)
+      retribution_spell_label = Gtk::Label.new('retribution spell:')
+      retribution_spell_entry = Gtk::Entry.new
+      retribution_spell_entry.text = retribution_spell.to_s
+      retribution_spell_entry.width_request = 50
+      temp_box = Gtk::Box.new(:horizontal, 0)
+      temp_box.pack_end(retribution_spell_entry, expand: false, fill: false, padding: 5)
+      temp_box.pack_end(retribution_spell_label, expand: false, fill: false, padding: 5)
+      other_option_box.pack_start(temp_box, expand: false, fill: false, padding: 4)
 
-         reserve_mana_label = Gtk::Label.new('reserve mana:')
-         reserve_mana_entry = Gtk::Entry.new
-         reserve_mana_entry.text = reserve_mana.to_s
-         reserve_mana_entry.width_request = 50
-         temp_box = Gtk::Box.new(:horizontal, 0)
-         temp_box.pack_end(reserve_mana_entry, :expand => false, :fill => false, :padding => 5)
-         temp_box.pack_end(reserve_mana_label, :expand => false, :fill => false, :padding => 5)
-         other_option_box.pack_start(temp_box, :expand => false, :fill => false, :padding => 4)
+      reserve_mana_label = Gtk::Label.new('reserve mana:')
+      reserve_mana_entry = Gtk::Entry.new
+      reserve_mana_entry.text = reserve_mana.to_s
+      reserve_mana_entry.width_request = 50
+      temp_box = Gtk::Box.new(:horizontal, 0)
+      temp_box.pack_end(reserve_mana_entry, expand: false, fill: false, padding: 5)
+      temp_box.pack_end(reserve_mana_label, expand: false, fill: false, padding: 5)
+      other_option_box.pack_start(temp_box, expand: false, fill: false, padding: 4)
 
-         other_option_box_spacer = Gtk::Box.new(:vertical)
-         other_option_box_spacer.pack_start(other_option_box, :expand => false, :fill => false, :padding => 4)
+      other_option_box_spacer = Gtk::Box.new(:vertical)
+      other_option_box_spacer.pack_start(other_option_box, expand: false, fill: false, padding: 4)
 
-         other_option_frame = Gtk::Frame.new('Options')
-         other_option_frame.add(other_option_box_spacer)
+      other_option_frame = Gtk::Frame.new('Options')
+      other_option_frame.add(other_option_box_spacer)
 
-         left_box = Gtk::Box.new(:vertical, 0)
-         left_box.pack_start(stack_frame, :expand => false, :fill => false, :padding => 5)
-         left_box.pack_start(nonstack_frame, :expand => false, :fill => false, :padding => 5)
-         left_box.pack_start(other_option_frame, :expand => false, :fill => false, :padding => 5)
+      left_box = Gtk::Box.new(:vertical, 0)
+      left_box.pack_start(stack_frame, expand: false, fill: false, padding: 5)
+      left_box.pack_start(nonstack_frame, expand: false, fill: false, padding: 5)
+      left_box.pack_start(other_option_frame, expand: false, fill: false, padding: 5)
 
-         use_multicast_option            = Gtk::CheckButton.new('multicast')
-         use_multicast_option.active     = use_multicast
-         use_wracking_option             = Gtk::CheckButton.new('wracking')
-         use_wracking_option.active      = use_wracking
-         wander_to_wrack_option          = Gtk::CheckButton.new('wander to wrack')
-         wander_to_wrack_option.active   = wander_to_wrack
-         use_power_option                = Gtk::CheckButton.new('power')
-         use_power_option.active         = use_power
-         use_concentration_option        = Gtk::CheckButton.new('concentration')
-         use_concentration_option.active = use_concentration
-         use_mana_option                 = Gtk::CheckButton.new('mana')
-         use_mana_option.active          = use_mana
-         skip_jerks_option               = Gtk::CheckButton.new('skip jerks')
-         skip_jerks_option.active        = skip_jerks
-         skip_short_option               = Gtk::CheckButton.new('skip short spells on others')
-         skip_short_option.active        = skip_short_spells
+      use_multicast_option            = Gtk::CheckButton.new('multicast')
+      use_multicast_option.active     = use_multicast
+      use_wracking_option             = Gtk::CheckButton.new('wracking')
+      use_wracking_option.active      = use_wracking
+      wander_to_wrack_option          = Gtk::CheckButton.new('wander to wrack')
+      wander_to_wrack_option.active   = wander_to_wrack
+      use_power_option                = Gtk::CheckButton.new('power')
+      use_power_option.active         = use_power
+      use_concentration_option        = Gtk::CheckButton.new('concentration')
+      use_concentration_option.active = use_concentration
+      use_mana_option                 = Gtk::CheckButton.new('mana')
+      use_mana_option.active          = use_mana
+      skip_jerks_option               = Gtk::CheckButton.new('skip jerks')
+      skip_jerks_option.active        = skip_jerks
+      skip_short_option               = Gtk::CheckButton.new('skip short spells on others')
+      skip_short_option.active        = skip_short_spells
 
-         option_box = Gtk::Box.new(:vertical, 0)
-         option_box.pack_start(use_multicast_option, :expand => false, :fill => false, :padding => 4)
-         option_box.pack_start(use_wracking_option, :expand => false, :fill => false, :padding => 4)
-         option_box.pack_start(wander_to_wrack_option, :expand => false, :fill => false, :padding => 4)
-         option_box.pack_start(use_power_option, :expand => false, :fill => false, :padding => 4)
-         option_box.pack_start(use_concentration_option, :expand => false, :fill => false, :padding => 4)
-         option_box.pack_start(use_mana_option, :expand => false, :fill => false, :padding => 4)
-         option_box.pack_start(skip_jerks_option, :expand => false, :fill => false, :padding => 4)
-         option_box.pack_start(skip_short_option, :expand => false, :fill => false, :padding => 4)
+      option_box = Gtk::Box.new(:vertical, 0)
+      option_box.pack_start(use_multicast_option, expand: false, fill: false, padding: 4)
+      option_box.pack_start(use_wracking_option, expand: false, fill: false, padding: 4)
+      option_box.pack_start(wander_to_wrack_option, expand: false, fill: false, padding: 4)
+      option_box.pack_start(use_power_option, expand: false, fill: false, padding: 4)
+      option_box.pack_start(use_concentration_option, expand: false, fill: false, padding: 4)
+      option_box.pack_start(use_mana_option, expand: false, fill: false, padding: 4)
+      option_box.pack_start(skip_jerks_option, expand: false, fill: false, padding: 4)
+      option_box.pack_start(skip_short_option, expand: false, fill: false, padding: 4)
 
-         option_box_spacer = Gtk::Box.new(:vertical)
-         option_box_spacer.pack_start(option_box, :expand => false, :fill => false, :padding => 4)
+      option_box_spacer = Gtk::Box.new(:vertical)
+      option_box_spacer.pack_start(option_box, expand: false, fill: false, padding: 4)
 
-         option_frame = Gtk::Frame.new('Options')
-         option_frame.add(option_box_spacer)
+      option_frame = Gtk::Frame.new('Options')
+      option_frame.add(option_box_spacer)
 
-         columns = Gtk::Box.new(:horizontal, 0)
+      columns = Gtk::Box.new(:horizontal, 0)
 
-         right_box = Gtk::Box.new(:vertical)
-         right_box.pack_start(option_frame, :expand => false, :fill => false, :padding => 0)
+      right_box = Gtk::Box.new(:vertical)
+      right_box.pack_start(option_frame, expand: false, fill: false, padding: 0)
 
-         columns.pack_start(left_box, :expand => false, :fill => false, :padding => 0)
-         columns.pack_start(right_box, :expand => false, :fill => false, :padding => 0)
+      columns.pack_start(left_box, expand: false, fill: false, padding: 0)
+      columns.pack_start(right_box, expand: false, fill: false, padding: 0)
 
-         save_button = Gtk::Button.new(:label => 'Ok')
-         save_button.width_request = 75
-         cancel_button = Gtk::Button.new(:label => 'Cancel')
-         cancel_button.width_request = 75
-         button_box = Gtk::Box.new(:horizontal, 3)
-         button_box.pack_end(save_button, :expand => false, :fill => false, :padding => 4)
-         button_box.pack_end(cancel_button, :expand => false, :fill => false, :padding => 4)
+      save_button = Gtk::Button.new(label: 'Ok')
+      save_button.width_request = 75
+      cancel_button = Gtk::Button.new(label: 'Cancel')
+      cancel_button.width_request = 75
+      button_box = Gtk::Box.new(:horizontal, 3)
+      button_box.pack_end(save_button, expand: false, fill: false, padding: 4)
+      button_box.pack_end(cancel_button, expand: false, fill: false, padding: 4)
 
-         main_box = Gtk::Box.new(:vertical, 4)
-         main_box.pack_start(label_box, :expand => false, :fill => false, :padding => 0)
-         main_box.pack_start(tree_box, :expand => true, :fill => true, :padding => 0)
-         main_box.pack_start(columns, :expand => false, :fill => false, :padding => 0)
-         main_box.pack_start(button_box, :expand => false, :fill => false, :padding => 0)
+      main_box = Gtk::Box.new(:vertical, 4)
+      main_box.pack_start(label_box, expand: false, fill: false, padding: 0)
+      main_box.pack_start(tree_box, expand: true, fill: true, padding: 0)
+      main_box.pack_start(columns, expand: false, fill: false, padding: 0)
+      main_box.pack_start(button_box, expand: false, fill: false, padding: 0)
 
-         window = Gtk::Window.new
-         window.title = 'waggle setup'
-         window.border_width = 5
-         window.add(main_box)
-         window.resize(window_width, window_height)
+      window = Gtk::Window.new
+      window.title = 'waggle setup'
+      window.border_width = 5
+      window.add(main_box)
+      window.resize(window_width, window_height)
 
-         Spells.known.each { |spell|
-            next unless (Spell[spell].time_per > 0)
-            if cast_list.include?(spell.num)
-               iter = cast_ls.append
-               iter[0] = spell.num.to_s
-               iter[1] = spell.name
-            else
-               iter = nocast_ls.append
-               iter[0] = spell.num.to_s
-               iter[1] = spell.name
-            end
-         }
+      Spells.known.each do |spell|
+        next unless Spell[spell].time_per > 0
 
-         cast_tv.drag_source_set(:button1_mask, [ [ 'text/plain', :same_app, 0 ] ], :move)
-         cast_tv.drag_dest_set( :all, [ [ 'text/plain', Gtk::Drag::TARGET_SAME_APP, 0 ] ], Gdk::DragContext::ACTION_MOVE)
-         Gtk::Drag.source_set(nocast_tv, Gdk::Window::BUTTON1_MASK, [ [ 'text/plain', Gtk::Drag::TARGET_SAME_APP, 0 ] ], Gdk::DragContext::ACTION_MOVE)
-         Gtk::Drag.dest_set(nocast_tv, Gtk::Drag::DEST_DEFAULT_ALL, [ [ 'text/plain', Gtk::Drag::TARGET_SAME_APP, 0 ] ], Gdk::DragContext::ACTION_MOVE)
-
-         cast_tv.signal_connect('drag-data-get') { |who, drag_context, data|
-            data.text = who.selection.selected[0] if who.selection.selected
-         }
-         cast_tv.signal_connect('drag-data-received') { |who, drag_context, x, y, data, info, time|
-            nocast_ls.each { |model,path,iter|
-               if iter[0] == data.text
-                  new_iter = cast_ls.append
-                  new_iter[0] = iter[0]
-                  new_iter[1] = iter[1]
-                  nocast_ls.remove(iter)
-                  break
-               end
-            }
-         }
-         cast_tv.signal_connect('button-press-event') { |who, event|
-            if (event.event_type == Gdk::Event::BUTTON2_PRESS) and (source_iter = cast_tv.selection.selected)
-               dest_iter = nocast_ls.append
-               dest_iter[0] = source_iter[0]
-               dest_iter[1] = source_iter[1]
-               cast_ls.remove(source_iter)
-            end
-         }
-         nocast_tv.signal_connect('drag-data-get') { |who, drag_context, data|
-            data.text = who.selection.selected[0] if who.selection.selected
-         }
-         nocast_tv.signal_connect('drag-data-received') { |who, drag_context, x, y, data, info, time|
-            cast_ls.each { |model,path,iter|
-               if iter[0] == data.text
-                  new_iter = nocast_ls.append
-                  new_iter[0] = iter[0]
-                  new_iter[1] = iter[1]
-                  cast_ls.remove(iter)
-                  break
-               end
-            }
-         }
-         nocast_tv.signal_connect('button-press-event') { |who, event|
-            if (event.event_type == :button2_press) and (source_iter = nocast_tv.selection.selected)
-               dest_iter = cast_ls.append
-               dest_iter[0] = source_iter[0]
-               dest_iter[1] = source_iter[1]
-               nocast_ls.remove(source_iter)
-            end
-         }
-         cancel_button.signal_connect('clicked') {
-            window_width = window.allocation.width
-            window_height = window.allocation.height
-            window_action = :cancel
-         }
-         save_button.signal_connect('clicked') {
-            Gtk.queue {
-               cast_list = Array.new
-               cast_ls.each { |model,path,iter| cast_list.push(iter[0].to_i) }
-               if start_at_entry.text =~ /^[0-9]+$/i
-                  start_at = start_at_entry.text.to_i
-               else
-                  respond "[waggle: ignoring invalid entry: #{start_at_entry.text}]"
-               end
-               if stop_at_entry.text =~ /^[0-9]+$/i
-                  stop_at = stop_at_entry.text.to_i
-               else
-                  respond "[waggle: ignoring invalid entry: #{stop_at_entry.text}]"
-               end
-               if stop_before_entry.text =~ /^[0-9]+$/i
-                  stop_before = stop_before_entry.text.to_i
-               else
-                  respond "[waggle: ignoring invalid entry: #{stop_before_entry.text}]"
-               end
-               if nonstack_min_entry.text =~ /^[0-9]+$/i
-                  refreshable_min = nonstack_min_entry.text.to_i
-               else
-                  respond "[waggle: ignoring invalid entry: #{nonstack_min_entry.text}]"
-               end
-               if retribution_spell_entry.text =~ /^[0-9]+$/i
-                  retribution_spell = retribution_spell_entry.text
-               elsif retribution_spell_entry.text.empty? or retribution_spell_entry.text =~ /none|off/
-                  retribution_spell = nil
-               else
-                  respond "[waggle: ignoring invalid entry: #{retribution_spell_entry.text}]"
-               end
-               if reserve_mana_entry.text =~ /^[0-9]+$/i
-                  reserve_mana = reserve_mana_entry.text.to_i
-               elsif reserve_mana_entry.text.empty?
-                  reserve_mana = 0
-               else
-                  respond "[waggle: ignoring invalid entry: #{reserve_mana_entry.text}]"
-               end
-               use_multicast     = use_multicast_option.active?
-               use_wracking      = use_wracking_option.active?
-               wander_to_wrack   = wander_to_wrack_option.active?
-               use_power         = use_power_option.active?
-               use_concentration = use_concentration_option.active?
-               use_mana          = use_mana_option.active?
-               skip_jerks        = skip_jerks_option.active?
-               skip_short_spells = skip_short_option.active?
-               window_width      = window.allocation.width
-               window_height     = window.allocation.height
-               window_action     = :save
-            }
-         }
-         window.signal_connect('delete_event') {
-            window_width = window.allocation.width
-            window_height = window.allocation.height
-            window_action = :cancel
-         }
-
-         window.show_all
-      }
-      before_dying { Gtk.queue { window.destroy } }
-      wait_while { window_action.nil? }
-      undo_before_dying
-      Gtk.queue { window.destroy }
-      CharSettings['window_width']  = window_width
-      CharSettings['window_height'] = window_height
-      if window_action == :save
-         CharSettings['use_multicast']     = use_multicast
-         CharSettings['use_wracking']      = use_wracking
-         CharSettings['wander_to_wrack']   = wander_to_wrack
-         CharSettings['use_power']         = use_power
-         CharSettings['use_concentration'] = use_concentration
-         CharSettings['use_mana']          = use_mana
-         CharSettings['skip_jerks']        = skip_jerks
-         CharSettings['skip_short_spells'] = skip_short_spells
-         CharSettings['start_at']          = start_at
-         CharSettings['stop_at']           = stop_at
-         CharSettings['stop_before']       = stop_before
-         CharSettings['unstackable_min']   = refreshable_min
-         CharSettings['retribution_spell'] = retribution_spell
-         CharSettings['reserve_mana']      = reserve_mana
-         CharSettings['cast_list']         = cast_list
+        if cast_list.include?(spell.num)
+          iter = cast_ls.append
+          iter[0] = spell.num.to_s
+          iter[1] = spell.name
+        else
+          iter = nocast_ls.append
+          iter[0] = spell.num.to_s
+          iter[1] = spell.name
+        end
       end
-   else
-      unless HAVE_GTK
-         echo 'GTK bindings are not installed or failed to load.'
-         echo "For command-line setup, see #{$clean_lich_char}#{script.name} help"
-         exit
+
+      cast_tv.drag_source_set(:button1_mask, [['text/plain', :same_app, 0]], :move)
+      cast_tv.drag_dest_set(:all, [['text/plain', :same_app, 0]], :move)
+      nocast_tv.drag_source_set(:button1_mask, [['text/plain', :same_app, 0]], :move)
+      nocast_tv.drag_dest_set(:all, [['text/plain', :same_app, 0]], :move)
+
+      cast_tv.signal_connect('drag-data-get') do |who, _drag_context, data|
+        data.text = who.selection.selected[0] if who.selection.selected
       end
-      unless defined?(Gtk.queue)
-         echo "GUI setup requires Lich v4."
-         echo "For command-line setup, see #{$clean_lich_char}#{script.name} help"
-         exit
+      cast_tv.signal_connect('drag-data-received') do |_who, _drag_context, _x, _y, data, _info, _time|
+        nocast_ls.each do |_model, _path, iter|
+          next unless iter[0] == data.text
+
+          new_iter = cast_ls.append
+          new_iter[0] = iter[0]
+          new_iter[1] = iter[1]
+          nocast_ls.remove(iter)
+          break
+        end
       end
-   end
-   exit
+      cast_tv.signal_connect('button-press-event') do |_who, event|
+        if (event.event_type == Gdk::Event::BUTTON2_PRESS) && (source_iter = cast_tv.selection.selected)
+          dest_iter = nocast_ls.append
+          dest_iter[0] = source_iter[0]
+          dest_iter[1] = source_iter[1]
+          cast_ls.remove(source_iter)
+        end
+      end
+      nocast_tv.signal_connect('drag-data-get') do |who, _drag_context, data|
+        data.text = who.selection.selected[0] if who.selection.selected
+      end
+      nocast_tv.signal_connect('drag-data-received') do |_who, _drag_context, _x, _y, data, _info, _time|
+        cast_ls.each do |_model, _path, iter|
+          next unless iter[0] == data.text
+
+          new_iter = nocast_ls.append
+          new_iter[0] = iter[0]
+          new_iter[1] = iter[1]
+          cast_ls.remove(iter)
+          break
+        end
+      end
+      nocast_tv.signal_connect('button-press-event') do |_who, event|
+        if (event.event_type == :button2_press) && (source_iter = nocast_tv.selection.selected)
+          dest_iter = cast_ls.append
+          dest_iter[0] = source_iter[0]
+          dest_iter[1] = source_iter[1]
+          nocast_ls.remove(source_iter)
+        end
+      end
+      cancel_button.signal_connect('clicked') do
+        window_width = window.allocation.width
+        window_height = window.allocation.height
+        window_action = :cancel
+      end
+      save_button.signal_connect('clicked') do
+        Gtk.queue do
+          cast_list = []
+          cast_ls.each { |_model, _path, iter| cast_list.push(iter[0].to_i) }
+          if start_at_entry.text =~ /^[0-9]+$/i
+            start_at = start_at_entry.text.to_i
+          else
+            respond "[waggle: ignoring invalid entry: #{start_at_entry.text}]"
+          end
+          if stop_at_entry.text =~ /^[0-9]+$/i
+            stop_at = stop_at_entry.text.to_i
+          else
+            respond "[waggle: ignoring invalid entry: #{stop_at_entry.text}]"
+          end
+          if stop_before_entry.text =~ /^[0-9]+$/i
+            stop_before = stop_before_entry.text.to_i
+          else
+            respond "[waggle: ignoring invalid entry: #{stop_before_entry.text}]"
+          end
+          if nonstack_min_entry.text =~ /^[0-9]+$/i
+            refreshable_min = nonstack_min_entry.text.to_i
+          else
+            respond "[waggle: ignoring invalid entry: #{nonstack_min_entry.text}]"
+          end
+          if retribution_spell_entry.text =~ /^[0-9]+$/i
+            retribution_spell = retribution_spell_entry.text
+          elsif retribution_spell_entry.text.empty? || retribution_spell_entry.text =~ (/none|off/)
+            retribution_spell = nil
+          else
+            respond "[waggle: ignoring invalid entry: #{retribution_spell_entry.text}]"
+          end
+          if reserve_mana_entry.text =~ /^[0-9]+$/i
+            reserve_mana = reserve_mana_entry.text.to_i
+          elsif reserve_mana_entry.text.empty?
+            reserve_mana = 0
+          else
+            respond "[waggle: ignoring invalid entry: #{reserve_mana_entry.text}]"
+          end
+          use_multicast     = use_multicast_option.active?
+          use_wracking      = use_wracking_option.active?
+          wander_to_wrack   = wander_to_wrack_option.active?
+          use_power         = use_power_option.active?
+          use_concentration = use_concentration_option.active?
+          use_mana          = use_mana_option.active?
+          skip_jerks        = skip_jerks_option.active?
+          skip_short_spells = skip_short_option.active?
+          window_width      = window.allocation.width
+          window_height     = window.allocation.height
+          window_action     = :save
+        end
+      end
+      window.signal_connect('delete_event') do
+        window_width = window.allocation.width
+        window_height = window.allocation.height
+        window_action = :cancel
+      end
+
+      window.show_all
+    end
+    before_dying { Gtk.queue { window.destroy } }
+    wait_while { window_action.nil? }
+    undo_before_dying
+    Gtk.queue { window.destroy }
+    CharSettings['window_width']  = window_width
+    CharSettings['window_height'] = window_height
+    if window_action == :save
+      CharSettings['use_multicast'] = use_multicast
+      CharSettings['use_wracking']      = use_wracking
+      CharSettings['wander_to_wrack']   = wander_to_wrack
+      CharSettings['use_power']         = use_power
+      CharSettings['use_concentration'] = use_concentration
+      CharSettings['use_mana']          = use_mana
+      CharSettings['skip_jerks']        = skip_jerks
+      CharSettings['skip_short_spells'] = skip_short_spells
+      CharSettings['start_at']          = start_at
+      CharSettings['stop_at']           = stop_at
+      CharSettings['stop_before']       = stop_before
+      CharSettings['unstackable_min']   = refreshable_min
+      CharSettings['retribution_spell'] = retribution_spell
+      CharSettings['reserve_mana']      = reserve_mana
+      CharSettings['cast_list']         = cast_list
+    end
+  else
+    unless HAVE_GTK
+      echo 'GTK bindings are not installed or failed to load.'
+      echo "For command-line setup, see #{$clean_lich_char}#{script.name} help"
+      exit
+    end
+    unless defined?(Gtk.queue)
+      echo "GUI setup requires Lich v5."
+      echo "For command-line setup, see #{$clean_lich_char}#{script.name} help"
+      exit
+    end
+  end
+  exit
 elsif script.vars[1].downcase == 'add'
-   add_list = script.vars[2..-1].collect { |spell| spell.to_i }
-   add_list.each { |spell|
-      cast_list.push(spell.to_i) unless cast_list.include?(spell.to_i)
-   }
-   echo "added these spells to the cast list: #{add_list.join(', ')}"
-   CharSettings['cast_list'] = cast_list
-   exit
+  add_list = script.vars[2..-1].collect { |spell| spell.to_i }
+  add_list.each do |spell|
+    cast_list.push(spell.to_i) unless cast_list.include?(spell.to_i)
+  end
+  echo "added these spells to the cast list: #{add_list.join(', ')}"
+  CharSettings['cast_list'] = cast_list
+  exit
 elsif script.vars[1] =~ /^rem(?:ove)?$|^del(?:ete)?$/i
-   del_list = script.vars[2..-1].collect { |spell| spell.to_i }
-   del_list.each { |spell|
-      if cast_list.delete(spell)
-         echo "removed #{spell} from the cast list"
-      else
-         echo "did not find #{spell} in the cast list"
-      end
-   }
-   CharSettings['cast_list'] = cast_list
-   exit
+  del_list = script.vars[2..-1].collect { |spell| spell.to_i }
+  del_list.each do |spell|
+    if cast_list.delete(spell)
+      echo "removed #{spell} from the cast list"
+    else
+      echo "did not find #{spell} in the cast list"
+    end
+  end
+  CharSettings['cast_list'] = cast_list
+  exit
 elsif script.vars[1] =~ /^list$|^show$/i
-   fix_setting = { true => 'on', false => 'off' }
-   respond
-   respond "             cast list: #{cast_list.join(', ')}"
-   respond "              start at: #{start_at}"
-   respond "               stop at: #{stop_at}"
-   respond "           stop before: #{stop_before}"
-   respond "       refreshable min: #{refreshable_min}"
-   respond "             multicast: #{fix_setting[use_multicast]}"
-   respond "      sign of wracking: #{fix_setting[use_wracking]}"
-   respond "       wander to wrack: #{fix_setting[wander_to_wrack]}"
-   respond "        sigil of power: #{fix_setting[use_power]}"
-   respond "sigil of concentration: #{fix_setting[use_concentration]}"
-   respond "        symbol of mana: #{fix_setting[use_mana]}"
-   respond "            skip jerks: #{fix_setting[skip_jerks]}"
-   respond "     skip short spells: #{fix_setting[skip_short_spells]}"
-   respond "     retribution spell: #{retribution_spell || 'none'}"
-   respond "          reserve mana: #{reserve_mana}"
-   respond
-   exit
+  fix_setting = { true => 'on', false => 'off' }
+  respond
+  respond "             cast list: #{cast_list.join(', ')}"
+  respond "              start at: #{start_at}"
+  respond "               stop at: #{stop_at}"
+  respond "           stop before: #{stop_before}"
+  respond "       refreshable min: #{refreshable_min}"
+  respond "             multicast: #{fix_setting[use_multicast]}"
+  respond "      sign of wracking: #{fix_setting[use_wracking]}"
+  respond "       wander to wrack: #{fix_setting[wander_to_wrack]}"
+  respond "        sigil of power: #{fix_setting[use_power]}"
+  respond "sigil of concentration: #{fix_setting[use_concentration]}"
+  respond "        symbol of mana: #{fix_setting[use_mana]}"
+  respond "            skip jerks: #{fix_setting[skip_jerks]}"
+  respond "     skip short spells: #{fix_setting[skip_short_spells]}"
+  respond "     retribution spell: #{retribution_spell || 'none'}"
+  respond "          reserve mana: #{reserve_mana}"
+  respond
+  exit
 elsif script.vars[1].downcase == /^start[_\-]at$/
-   if script.vars[2] =~ /^[0-9]+$/
-      CharSettings['start_at'] = script.vars[2].to_i
-      echo "stackable spells with less than #{CharSettings['start_at']} minutes remaining when the script starts will be skipped"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2] =~ /^[0-9]+$/
+    CharSettings['start_at'] = script.vars[2].to_i
+    echo "stackable spells with less than #{CharSettings['start_at']} minutes remaining when the script starts will be skipped"
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^stop[_\-]at$/
-   if script.vars[2] =~ /^[0-9]+$/
-      CharSettings['stop_at'] = script.vars[2].to_i
-      echo "stackable spells will be cast until they have #{CharSettings['stop_at']} minutes remaining"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2] =~ /^[0-9]+$/
+    CharSettings['stop_at'] = script.vars[2].to_i
+    echo "stackable spells will be cast until they have #{CharSettings['stop_at']} minutes remaining"
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^stop[_\-]before$/
-   if script.vars[2] =~ /^[0-9]+$/
-      CharSettings['stop_before'] = script.vars[2].to_i
-      echo "stackable spells will not be cast if it would cause the spell to have more than #{CharSettings['stop_before']} minutes remaing"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2] =~ /^[0-9]+$/
+    CharSettings['stop_before'] = script.vars[2].to_i
+    echo "stackable spells will not be cast if it would cause the spell to have more than #{CharSettings['stop_before']} minutes remaing"
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase == /^refreshable[_\-]?min$/
-   if script.vars[2] =~ /^[0-9]+$/
-      CharSettings['unstackable_min'] = script.vars[2].to_i
-      echo "non-stackable spells will be cast if they have less than #{CharSettings['unstackable_min']} minutes remaining"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2] =~ /^[0-9]+$/
+    CharSettings['unstackable_min'] = script.vars[2].to_i
+    echo "non-stackable spells will be cast if they have less than #{CharSettings['unstackable_min']} minutes remaining"
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^(?:use[_\-])?multicast$/
-   if script.vars[2].downcase == 'on'
-      CharSettings['use_multicast'] = true
-      echo "multicast will be used"
-   elsif script.vars[2].downcase == 'off'
-      CharSettings['use_multicast'] = false
-      echo "multicast will not be used"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase == 'on'
+    CharSettings['use_multicast'] = true
+    echo 'multicast will be used'
+  elsif script.vars[2].downcase == 'off'
+    CharSettings['use_multicast'] = false
+    echo 'multicast will not be used'
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^(?:use[_\-])?wracking$/
-   if script.vars[2].downcase == 'on'
-      CharSettings['use_wracking'] = true
-      echo "sign of wracking will be used"
-   elsif script.vars[2].downcase == 'off'
-      CharSettings['use_wracking'] = false
-      echo "sign of wracking will not be used"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase == 'on'
+    CharSettings['use_wracking'] = true
+    echo 'sign of wracking will be used'
+  elsif script.vars[2].downcase == 'off'
+    CharSettings['use_wracking'] = false
+    echo 'sign of wracking will not be used'
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^wander(?:[_\-]to[_\-]wrack)?$/
-   if script.vars[2].downcase == 'on'
-      CharSettings['wander_to_wrack'] = true
-      echo "wander will be used to wrack"
-   elsif script.vars[2].downcase == 'off'
-      CharSettings['wander_to_wrack'] = false
-      echo "wander will not be used to wrack"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase == 'on'
+    CharSettings['wander_to_wrack'] = true
+    echo 'wander will be used to wrack'
+  elsif script.vars[2].downcase == 'off'
+    CharSettings['wander_to_wrack'] = false
+    echo 'wander will not be used to wrack'
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^(?:use[_\-])?power$/
-   if script.vars[2].downcase == 'on'
-      CharSettings['use_power'] = true
-      echo "sigil of power will be used"
-   elsif script.vars[2].downcase == 'off'
-      CharSettings['use_power'] = false
-      echo "sigil of power will not be used"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase == 'on'
+    CharSettings['use_power'] = true
+    echo 'sigil of power will be used'
+  elsif script.vars[2].downcase == 'off'
+    CharSettings['use_power'] = false
+    echo 'sigil of power will not be used'
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^(?:use[_\-])?concentration$/
-   if script.vars[2].downcase == 'on'
-      CharSettings['use_concentration'] = true
-      echo "sigil of concentration will be used"
-   elsif script.vars[2].downcase == 'off'
-      CharSettings['use_concentration'] = false
-      echo "sigil of concentration will not be used"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase == 'on'
+    CharSettings['use_concentration'] = true
+    echo 'sigil of concentration will be used'
+  elsif script.vars[2].downcase == 'off'
+    CharSettings['use_concentration'] = false
+    echo 'sigil of concentration will not be used'
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^(?:use[_\-])?mana$/
-   if script.vars[2].downcase == 'on'
-      CharSettings['use_mana'] = true
-      echo "symbol of mana will be used"
-   elsif script.vars[2].downcase == 'off'
-      CharSettings['use_mana'] = false
-      echo "symbol of man will not be used"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase == 'on'
+    CharSettings['use_mana'] = true
+    echo 'symbol of mana will be used'
+  elsif script.vars[2].downcase == 'off'
+    CharSettings['use_mana'] = false
+    echo 'symbol of man will not be used'
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^skip[_\-]jerks$/
-   if script.vars[2].downcase == 'on'
-      CharSettings['skip_jerks'] = true
-      echo "jerks that don't share spell durations will be skipped"
-   elsif script.vars[2].downcase == 'off'
-      CharSettings['skip_jerks'] = false
-      echo "jerks that don't share spell durations will not be skipped"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase == 'on'
+    CharSettings['skip_jerks'] = true
+    echo "jerks that don't share spell durations will be skipped"
+  elsif script.vars[2].downcase == 'off'
+    CharSettings['skip_jerks'] = false
+    echo "jerks that don't share spell durations will not be skipped"
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^skip[_\-]short(?:[_\-]spells)?/
-   if script.vars[2].downcase == 'on'
-      CharSettings['skip_short_spells'] = true
-      echo "spells with a duration of less than #{short_spell_time} minutes per cast will not be cast on others"
-   elsif script.vars[2].downcase == 'off'
-      CharSettings['skip_short_spells'] = false
-      echo "short spells will not be skipped"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase == 'on'
+    CharSettings['skip_short_spells'] = true
+    echo "spells with a duration of less than #{short_spell_time} minutes per cast will not be cast on others"
+  elsif script.vars[2].downcase == 'off'
+    CharSettings['skip_short_spells'] = false
+    echo 'short spells will not be skipped'
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^retribution[_\-]spell$/
-   if script.vars[2].downcase =~ /^(?:off|none)$/
-      CharSettings['retribution_spell'] = nil
-      echo "retribution spell cleared"
-   elsif script.vars[2] =~ /^[0-9]+$/
-      CharSettings['retribution_spell'] = script.vars[2]
-      echo "retribution spell set to #{script.vars[2]}"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2].downcase =~ /^(?:off|none)$/
+    CharSettings['retribution_spell'] = nil
+    echo 'retribution spell cleared'
+  elsif script.vars[2] =~ /^[0-9]+$/
+    CharSettings['retribution_spell'] = script.vars[2]
+    echo "retribution spell set to #{script.vars[2]}"
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase =~ /^reserve[_\-]mana$/
-   if script.vars[2] =~ /^[0-9]+$/
-      CharSettings['reserve_mana'] = script.vars[2]
-      echo "reserve mana set to #{script.vars[2]}"
-   else
-      echo "You're doing it wrong..."
-   end
-   exit
+  if script.vars[2] =~ /^[0-9]+$/
+    CharSettings['reserve_mana'] = script.vars[2]
+    echo "reserve mana set to #{script.vars[2]}"
+  else
+    echo "You're doing it wrong..."
+  end
+  exit
 elsif script.vars[1].downcase == 'info'
-   list_mode = true
-   target_list = Array.new
-   if script.vars[2]
-      script.vars[2..-1].each { |bad_name|
-         if pc = GameObj.pcs.find { |pc| pc.noun =~ /^#{bad_name}/i }
-            target_list.push(pc.noun)
-         elsif Char.name =~ /^#{bad_name}/i
-            target_list.push(Char.name)
-         else
-            echo "bad target: #{bad_name}"
-         end
-      }
-   else
-      target_list = [ Char.name ]
-   end
-elsif script.vars[1]
-   target_list = Array.new
-   script.vars[1..-1].each { |bad_name|
+  list_mode = true
+  target_list = []
+  if script.vars[2]
+    script.vars[2..-1].each do |bad_name|
       if pc = GameObj.pcs.find { |pc| pc.noun =~ /^#{bad_name}/i }
-         target_list.push(pc.noun)
+        target_list.push(pc.noun)
       elsif Char.name =~ /^#{bad_name}/i
-         target_list.push(Char.name)
+        target_list.push(Char.name)
       else
-         echo "bad target: #{bad_name}"
+        echo "bad target: #{bad_name}"
       end
-   }
+    end
+  else
+    target_list = [Char.name]
+  end
+elsif script.vars[1]
+  target_list = []
+  script.vars[1..-1].each do |bad_name|
+    if pc = GameObj.pcs.find { |pc| pc.noun =~ /^#{bad_name}/i }
+      target_list.push(pc.noun)
+    elsif Char.name =~ /^#{bad_name}/i
+      target_list.push(Char.name)
+    else
+      echo "bad target: #{bad_name}"
+    end
+  end
 else
-   target_list = [ Char.name ]
+  target_list = [Char.name]
 end
 
 fix_spell = proc { |spell|
-   if (spell.class == Integer) or (spell.class == String and spell =~ /^[0-9]+$/)
-      spell = Spell[spell.to_i]
-   end
-   unless spell.class == Spell
-      echo 'error: missing spell information'
-      exit
-   end
-   spell
+  spell = Spell[spell.to_i] if spell.instance_of?(Integer) || (spell.instance_of?(String) && spell =~ (/^[0-9]+$/))
+  unless spell.instance_of?(Spell)
+    echo 'error: missing spell information'
+    exit
+  end
+  spell
 }
 
-wander_rooms = Array.new
+wander_rooms = []
 wander = proc {
-   room = Room.current
-   next_room_options = room.wayto.keys
-   next_room = next_room_options.find_all { |r| ((room.timeto[r].class == Float && room.timeto[r] <= 3) or (room.timeto[r].class == Proc && room.timeto[r].call != nil && room.timeto[r].call <= 3)) and not wander_rooms.include?(r)}
-   if next_room.empty?
-      next_room = wander_rooms.find { |r| next_room_options.include?(r) }
-   else
-      next_room = next_room[rand(next_room.length)]
-   end
-   wander_rooms.delete(next_room)
-   wander_rooms.push(next_room)
-   way = room.wayto[next_room]
-   if way.class == String
-      move(way)
-   else
-      way.call
-   end
+  room = Room.current
+  next_room_options = room.wayto.keys
+  next_room = next_room_options.find_all { |r| ((room.timeto[r].instance_of?(Float) && room.timeto[r] <= 3) or (room.timeto[r].instance_of?(Proc) && !room.timeto[r].call.nil? && room.timeto[r].call <= 3)) and !wander_rooms.include?(r) }
+  next_room = if next_room.empty?
+                wander_rooms.find { |r| next_room_options.include?(r) }
+              else
+                next_room[rand(next_room.length)]
+              end
+  wander_rooms.delete(next_room)
+  wander_rooms.push(next_room)
+  way = room.wayto[next_room]
+  if way.instance_of?(String)
+    move(way)
+  else
+    way.call
+  end
 }
 
 check_mana = proc { |spell, num_multicast|
-   unless spell.affordable?(:multicast => num_multicast) and ((spell.mana_cost == 0) or (mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana))
-      sigil_of_power          = Spell[9718]
-      sign_of_wracking        = Spell[9918]
-      symbol_of_mana          = Spell[9813]
-      symbol_of_mana_cooldown = Spell[9048]
-      punishment              = Spell[9012]
-      if use_power and sigil_of_power.known? and (spell.mana_cost > 0) and (mana < (spell.mana_cost(:multicast => num_multicast) + reserve_mana)) and (spell.stamina_cost == 0)
-         until spell.affordable?(:multicast => num_multicast) and (mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)
-            if sigil_of_power.affordable?
-               sigil_of_power.cast
-               sleep 0.2
-            else
-               fput 'release' unless checkprep == 'None'
-               echo 'waiting for mana...'
-               wait_until { (spell.affordable?(:multicast => num_multicast) and (mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)) or sigil_of_power.affordable? }
-            end
-         end
-      elsif use_mana and symbol_of_mana.known? and spell.mana_cost > 0
-         until spell.affordable?(:multicast => num_multicast) and (mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)
-            waitrt?
-            waitcastrt?
-            if not symbol_of_mana_cooldown.active?
-               # fixme: might spam if out of favor
-               symbol_of_mana.cast
-               sleep 0.2
-            else
-               fput 'release' unless checkprep == 'None'
-               echo 'waiting for mana or mana cooldown...'
-               wait_until { (spell.affordable?(:multicast => num_multicast) and (mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)) or not symbol_of_mana_cooldown.active? }
-            end
-         end
-      elsif use_wracking and sign_of_wracking.known? and not punishment.active? and (spell.mana_cost > 0) and (mana < (spell.mana_cost(:multicast => num_multicast) + reserve_mana))
-         until spell.affordable?(:multicast => num_multicast) and (mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)
-            waitrt?
-            waitcastrt?
-            if sign_of_wracking.affordable? and not punishment.active?
-               if invisible? or hidden? or not checkpcs
-                  sign_of_wracking.cast if checkspirit(6)
-               else
-                  status_tags
-                  evil_pcs = checkpcs
-                  result = dothistimeout 'sign of recognition', 5, /^You (?:touch|scratch|rub|tap|point to) your (?:right|left) (?:eyebrow|nostril|earlobe|shoulder|cheek) with your (?:right|left) (?:pinky|forefinger|thumb|index finger)\.$/
-                  unless result.nil?
-                     while (line = get) and (line !~ /<prompt/)
-                        if line =~ /<a.*?>([A-Z][a-z]+)<\/a> acknowledges your sign/
-                           evil_pcs.delete($1)
-                        end
-                     end
-                  end
-                  status_tags
-                  if sign_of_wracking.affordable? and (evil_pcs.nil? or evil_pcs.empty?)
-                     sign_of_wracking.cast if checkspirit(6)
-                  elsif sign_of_wracking.affordable? and wander_to_wrack
-                     start_room = Room.current
-                     20.times {
-                        break if (checkpcs.nil? or invisible?) and not Room.current.tags.include?('no-magic')
-                        wander.call
-                     }
-                     if (checkpcs.nil? or invisible?) and checkspirit(6) and not Room.current.tags.include?('no-magic')
-                        sign_of_wracking.cast
-                        unless start_room == Room.current
-                           start_script 'go2', [ start_room.id.to_s ]
-                           wait_while { running?('go2') }
-                        end
-                     else
-                        unless start_room == Room.current
-                           start_script 'go2', [ start_room.id.to_s ]
-                           wait_while { running?('go2') }
-                        end
-                        fput 'release' unless checkprep == 'None'
-                        echo 'waiting on mana... or evil people to go away...'
-                        wait_until { (spell.affordable?(:multicast => num_multicast) and (spell.mana_cost == 0 or mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)) or hidden? or invisible? or not checkpcs.to_a.any? { |pc| evil_pcs.include?(pc) } }
-                     end
-                  else
-                     fput 'release' unless checkprep == 'None'
-                     echo 'waiting on mana... or evil people to go away...'
-                     wait_until { (spell.affordable?(:multicast => num_multicast) and (spell.mana_cost == 0 or mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)) or hidden? or invisible? or not checkpcs.to_a.any? { |pc| evil_pcs.include?(pc) } }
-                  end
-               end
-            else
-               fput 'release' unless checkprep == 'None'
-               echo 'waiting for mana or spirit...'
-               wait_until { (spell.affordable?(:multicast => num_multicast) and (spell.mana_cost == 0 or mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana)) or sign_of_wracking.affordable? }
-            end
-         end
-      else
-         fput 'release' unless checkprep == 'None'
-         echo 'waiting for mana...'
-         wait_until { spell.affordable?(:multicast => num_multicast) and (spell.mana_cost == 0 or mana >= spell.mana_cost(:multicast => num_multicast) + reserve_mana) }
+  unless spell.affordable?(multicast: num_multicast) && ((spell.mana_cost == 0) || (mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana))
+    sigil_of_power = Spell[9718]
+    sign_of_wracking        = Spell[9918]
+    symbol_of_mana          = Spell[9813]
+    symbol_of_mana_cooldown = Spell[9048]
+    punishment              = Spell[9012]
+    if use_power && sigil_of_power.known? && (spell.mana_cost > 0) && (mana < (spell.mana_cost(multicast: num_multicast) + reserve_mana)) && (spell.stamina_cost == 0)
+      until spell.affordable?(multicast: num_multicast) && (mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana)
+        if sigil_of_power.affordable?
+          sigil_of_power.cast
+          sleep 0.2
+        else
+          fput 'release' unless checkprep == 'None'
+          echo 'waiting for mana...'
+          wait_until { (spell.affordable?(multicast: num_multicast) and (mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana)) or sigil_of_power.affordable? }
+        end
       end
-   end
+    elsif use_mana && symbol_of_mana.known? && (spell.mana_cost > 0)
+      until spell.affordable?(multicast: num_multicast) && (mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana)
+        waitrt?
+        waitcastrt?
+        if symbol_of_mana_cooldown.active?
+          # FIXME: might spam if out of favor
+          fput 'release' unless checkprep == 'None'
+          echo 'waiting for mana or mana cooldown...'
+          wait_until { (spell.affordable?(multicast: num_multicast) and (mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana)) or !symbol_of_mana_cooldown.active? }
+        else
+          symbol_of_mana.cast
+          sleep 0.2
+        end
+      end
+    elsif use_wracking && sign_of_wracking.known? && !punishment.active? && (spell.mana_cost > 0) && (mana < (spell.mana_cost(multicast: num_multicast) + reserve_mana))
+      until spell.affordable?(multicast: num_multicast) && (mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana)
+        waitrt?
+        waitcastrt?
+        if sign_of_wracking.affordable? && !punishment.active?
+          if invisible? || hidden? || !checkpcs
+            sign_of_wracking.cast if checkspirit(6)
+          else
+            status_tags
+            evil_pcs = checkpcs
+            result = dothistimeout 'sign of recognition', 5, /^You (?:touch|scratch|rub|tap|point to) your (?:right|left) (?:eyebrow|nostril|earlobe|shoulder|cheek) with your (?:right|left) (?:pinky|forefinger|thumb|index finger)\.$/
+            unless result.nil?
+              while (line = get) && (line !~ /<prompt/)
+                evil_pcs.delete(Regexp.last_match(1)) if line =~ %r{<a.*?>([A-Z][a-z]+)</a> acknowledges your sign}
+              end
+            end
+            status_tags
+            if sign_of_wracking.affordable? && (evil_pcs.nil? || evil_pcs.empty?)
+              sign_of_wracking.cast if checkspirit(6)
+            elsif sign_of_wracking.affordable? && wander_to_wrack
+              start_room = Room.current
+              20.times do
+                break if (checkpcs.nil? || invisible?) && !Room.current.tags.include?('no-magic')
+
+                wander.call
+              end
+              if (checkpcs.nil? || invisible?) && checkspirit(6) && !Room.current.tags.include?('no-magic')
+                sign_of_wracking.cast
+                unless start_room == Room.current
+                  start_script 'go2', [start_room.id.to_s]
+                  wait_while { running?('go2') }
+                end
+              else
+                unless start_room == Room.current
+                  start_script 'go2', [start_room.id.to_s]
+                  wait_while { running?('go2') }
+                end
+                fput 'release' unless checkprep == 'None'
+                echo 'waiting on mana... or evil people to go away...'
+                wait_until { (spell.affordable?(multicast: num_multicast) and (spell.mana_cost == 0 or mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana)) or hidden? or invisible? or !checkpcs.to_a.any? { |pc| evil_pcs.include?(pc) } }
+              end
+            else
+              fput 'release' unless checkprep == 'None'
+              echo 'waiting on mana... or evil people to go away...'
+              wait_until { (spell.affordable?(multicast: num_multicast) and (spell.mana_cost == 0 or mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana)) or hidden? or invisible? or !checkpcs.to_a.any? { |pc| evil_pcs.include?(pc) } }
+            end
+          end
+        else
+          fput 'release' unless checkprep == 'None'
+          echo 'waiting for mana or spirit...'
+          wait_until { (spell.affordable?(multicast: num_multicast) and (spell.mana_cost == 0 or mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana)) or sign_of_wracking.affordable? }
+        end
+      end
+    else
+      fput 'release' unless checkprep == 'None'
+      echo 'waiting for mana...'
+      wait_until { spell.affordable?(multicast: num_multicast) and (spell.mana_cost == 0 or mana >= spell.mana_cost(multicast: num_multicast) + reserve_mana) }
+    end
+  end
 }
 
 release_spell = proc {
-   unless checkprep == 'None'
-      dothistimeout 'release', 5, /^You feel the magic of your spell rush away from you\.$|^You don't have a prepared spell to release!$/
-   end
+  unless checkprep == 'None'
+    dothistimeout 'release', 5, /^You feel the magic of your spell rush away from you\.$|^You don't have a prepared spell to release!$/
+  end
+}
+
+check_stamina = proc { |spell, num_multicast|
+  unless spell.affordable?(multicast: num_multicast) && ((spell.mana_cost == 0) || (checkstamina >= (spell.mana_cost(multicast: num_multicast) * 2) + reserve_mana))
+    echo 'waiting for stamina...'
+    wait_until { spell.affordable?(multicast: num_multicast) and ((spell.mana_cost == 0) or (stamina >= (spell.mana_cost(multicast: num_multicast) * 2) + reserve_mana)) }
+  end
 }
 
 cast_spell = proc { |spell, target, num_multicast|
-   did_something = true
-   spell = fix_spell.call(spell)
-   result = nil
-   loop {
-      check_mana.call(spell, num_multicast)
-      if target == Char.name
-         if num_multicast > 1
-            cast_result = spell.cast(num_multicast.to_s)
-         else
-            cast_result = spell.cast
-         end
-      else
-         if num_multicast > 1
-            cast_result = spell.cast("at #{target} #{num_multicast}")
-         else
-            cast_result = spell.cast("at #{target}")
-         end
-      end
-      if cast_result =~ /^Be at peace my child, there is no need for spells of war in here\.$|Spells of War cannot be cast/
-         result = :bad_spell
-         break
-      elsif cast_result == 'Cast at what?'
-         result = :bad_target
-         break
-      elsif cast_result =~ /^\[Spell Hindrance for/
-         nil # try again
-      else
-         result = :success
-         break
-      end
-   }
-   result
+  did_something = true
+  spell = fix_spell.call(spell)
+  result = nil
+  loop do
+    Feat.known?(:mental_acuity) ? check_stamina.call(spell, num_multicast) : check_mana.call(spell, num_multicast)
+    cast_result = if target == Char.name
+                    if num_multicast > 1
+                      spell.cast(num_multicast.to_s)
+                    else
+                      spell.cast
+                    end
+                  elsif num_multicast > 1
+                    spell.cast("at #{target} #{num_multicast}")
+                  else
+                    spell.cast("at #{target}")
+                  end
+    if cast_result =~ /^Be at peace my child, there is no need for spells of war in here\.$|Spells of War cannot be cast/
+      result = :bad_spell
+      break
+    elsif cast_result == 'Cast at what?'
+      result = :bad_target
+      break
+    elsif cast_result =~ /^\[Spell Hindrance for/
+      nil # try again
+    else
+      result = :success
+      break
+    end
+  end
+  result
 }
 
 # mostly lifted from LostRanger stuff
-def wag_quiet_command(command, include_end = true, timeout=5)
-    result = []
-    done = false
-    name = "waggle_sa_squelch"
-    filter = false
-    thread = Thread.current
+def wag_quiet_command(command, include_end = true, timeout = 5)
+  result = []
+  done = false
+  name = 'waggle_sa_squelch'
+  filter = false
+  thread = Thread.current
 
-    begin
-        DownstreamHook.add(name, proc {|xml|
-            if filter
-                if xml =~ /<prompt time="/
-                    DownstreamHook.remove(name)
-                    filter = false
-                    done = true
-                    result << xml.rstrip if include_end
-                    thread.raise(Interrupt)
-                    next(include_end ? nil : xml)
-                else
-                    result << xml.rstrip
-                    next(nil)
-                end
-            elsif xml =~ /has spell sharing disabled/
-                result << xml.rstrip    
-                done = true
-                thread.raise(Interrupt)
-            elsif xml =~ /has the following active effects/
-                next(nil)
-            elsif xml =~ /([A-z0-9\s\'\(\)\-]+) \.* (([0-9]+)\:([0-9]+)\:([0-9]+)|Indefinite)/
-                filter = true
-                result << xml.rstrip
-                next(nil)
-            else
-                xml
-            end
-        })
-        fput command
-        sleep(timeout)
-        return nil
-    rescue Interrupt
-        return result
-    ensure
-        DownstreamHook.remove(name)
-    end
+  begin
+    DownstreamHook.add(name, proc { |xml|
+                               if filter
+                                 if xml =~ /<prompt time="/
+                                   DownstreamHook.remove(name)
+                                   filter = false
+                                   done = true
+                                   result << xml.rstrip if include_end
+                                   thread.raise(Interrupt)
+                                   next(include_end ? nil : xml)
+                                 else
+                                   result << xml.rstrip
+                                   next(nil)
+                                 end
+                               elsif xml =~ /has spell sharing disabled/
+                                 result << xml.rstrip
+                                 done = true
+                                 thread.raise(Interrupt)
+                               elsif xml =~ /has the following active effects/
+                                 next(nil)
+                               elsif xml =~ /\s+([A-z0-9\s'()\-]+) \.* (([0-9]+):([0-9]+):([0-9]+)|Indefinite)/
+                                 filter = true
+                                 result << xml.rstrip
+                                 next(nil)
+                               else
+                                 xml
+                               end
+                             })
+    fput command
+    sleep(timeout)
+    nil
+  rescue Interrupt
+    result
+  ensure
+    DownstreamHook.remove(name)
+  end
 end
 
 get_target_info = proc { |target|
-    res = wag_quiet_command("spell active #{target}")
-    target_info = Hash.new
-    if res[0] !~ /has spell sharing disabled/
-        res.each { |line|
-            # Parsing from Infomon
-            if line =~ /([A-z0-9\s\'\(\)\-]+) \.* (([0-9]+)\:([0-9]+)\:([0-9]+)|Indefinite)$/
-                spell_name = $1
-                if $2 == 'Indefinite'
-                    spell_time = 599.0
-                else
-                    spell_time = ($3.to_i * 60) + $4.to_i + ($5.to_i / 60.0)
-                end
-                if spell_name == 'Raise Dead Recovery'
-                    # fixme
-                    spell_name = 'Raise Dead Cooldown'
-                elsif spell_name =~ /^Mage Armor \- /
-                    spell_name = 'Mage Armor'
-                elsif spell_name =~ /^Cloak of Shadows \- /
-                    spell_name = 'Cloak of Shadows'
-                end
-                if spell = Spell.list.find { |s| s.name == spell_name.strip() or s.num.to_s == spell_name.strip() }
-                    target_info[spell.num.to_s] = spell_time
-                else
-                    echo "no spell matches #{spell_name}" if $infomon_debug
-                end
-            end
-        }
-        target_info
-    elsif defined?(LNet.get_data)
-        echo "#{target} has spell privacy enabled, attempting to use LNet"
-        LNet.get_data(target, 'spells')
-    else
-        nil
+  res = wag_quiet_command("spell active #{target}")
+  target_info = {}
+  if res[0] !~ /has spell sharing disabled/
+    res.each do |line|
+      # Parsing from Infomon
+      next unless line =~ /\s+([A-z0-9\s'()\-]+) \.* (([0-9]+):([0-9]+):([0-9]+)|Indefinite)$/
+
+      spell_name = Regexp.last_match(1)
+      spell_time = if Regexp.last_match(2) == 'Indefinite'
+                     599.0
+                   else
+                     (Regexp.last_match(3).to_i * 60) + Regexp.last_match(4).to_i + (Regexp.last_match(5).to_i / 60.0)
+                   end
+      if spell_name == 'Raise Dead Recovery'
+        # fixme
+        spell_name = 'Raise Dead Cooldown'
+      elsif spell_name =~ /Mage Armor - /
+        spell_name = 'Mage Armor'
+      elsif spell_name =~ /Cloak of Shadows - /
+        spell_name = 'Cloak of Shadows'
+      end
+      if spell = Spell.list.find { |s| (s.name == spell_name.strip) || (s.num.to_s == spell_name.strip) }
+        target_info[spell.num.to_s] = spell_time
+      elsif $infomon_debug
+        echo "no spell matches #{spell_name}"
+      end
     end
+    target_info
+  elsif defined?(LNet.get_data)
+    echo "#{target} has spell privacy enabled, attempting to use LNet"
+    LNet.get_data(target, 'spells')
+  end
 }
 
-
-max_multicast = proc{ |spell|
-   ranks = 0
-   if Char.prof == 'Wizard'
-      ranks = Skills.emc
-   elsif Char.prof =~ /^Cleric$|^Ranger$|^Paladin$/
-      ranks = Skills.smc
-   elsif Char.prof =~ /^Empath$|^Monk$|^Bard$/
-      if [1,2].include?(spell.circle.to_i)
-         ranks = Skills.smc + (Skills.mmc / 2)
-      elsif spell.circle.to_i == 11
-         ranks = [Skills.mmc,Skills.smc].max + ([Skills.mmc,Skills.smc].min / 2)
-      elsif spell.circle.to_i == 12
-         ranks = Skills.mmc + (Skills.smc / 2)
-      elsif spell.circle.to_i == 4
-         ranks = Skills.emc + (Skills.mmc / 2)
-      end
-   elsif Char.prof =~ /^Sorcerer$|^Warrior$|^Rogue$/
-      if spell.circle.to_i == 4
-         ranks = Skills.emc + (Skills.smc / 2)
-      elsif spell.circle.to_i == 1
-         ranks = Skills.smc + (Skills.emc / 2)
-      elsif spell.circle.to_i == 7
-         ranks = [Skills.emc,Skills.smc].max + ([Skills.emc,Skills.smc].min / 2)
-      end
-   end
-   (ranks / 25) + 1
+max_multicast = proc { |spell|
+  ranks = 0
+  if Char.prof == 'Wizard'
+    ranks = Skills.emc
+  elsif Char.prof =~ /^Cleric$|^Ranger$|^Paladin$/
+    ranks = Skills.smc
+  elsif Char.prof =~ /^Empath$|^Monk$|^Bard$/
+    if [1, 2].include?(spell.circle.to_i)
+      ranks = Skills.smc + (Skills.mmc / 2)
+    elsif spell.circle.to_i == 11
+      ranks = [Skills.mmc, Skills.smc].max + ([Skills.mmc, Skills.smc].min / 2)
+    elsif spell.circle.to_i == 12
+      ranks = Skills.mmc + (Skills.smc / 2)
+    elsif spell.circle.to_i == 4
+      ranks = Skills.emc + (Skills.mmc / 2)
+    end
+  elsif Char.prof =~ /^Sorcerer$|^Warrior$|^Rogue$/
+    if spell.circle.to_i == 4
+      ranks = Skills.emc + (Skills.smc / 2)
+    elsif spell.circle.to_i == 1
+      ranks = Skills.smc + (Skills.emc / 2)
+    elsif spell.circle.to_i == 7
+      ranks = [Skills.emc, Skills.smc].max + ([Skills.emc, Skills.smc].min / 2)
+    end
+  end
+  (ranks / 25) + 1
 }
 
 #
 # gather current spell info for the targets
 #
-target_info = Hash.new
-target_list.each { |name|
-   if name == Char.name
-      target_info[Char.name] = Hash.new
-      Spell.active.each { |spell| target_info[Char.name][spell.num.to_s] = spell.timeleft }
-   elsif skip_jerks
-      spell_info = get_target_info.call(name)
-      if spell_info.nil?
-         echo "skipping #{name}: spell info refused"
-      elsif spell_info == false
-         echo "skipping #{name}: spell info failure"
-      else
-         target_info[name] = spell_info
-      end
-   else
-      target_info[name] = get_target_info.call(name) || Hash.new
-   end
-}
+target_info = {}
+target_list.each do |name|
+  if name == Char.name
+    target_info[Char.name] = {}
+    Spell.active.each { |spell| target_info[Char.name][spell.num.to_s] = spell.timeleft }
+  elsif skip_jerks
+    spell_info = get_target_info.call(name)
+    if spell_info.nil?
+      echo "skipping #{name}: spell info refused"
+    elsif spell_info == false
+      echo "skipping #{name}: spell info failure"
+    else
+      target_info[name] = spell_info
+    end
+  else
+    target_info[name] = get_target_info.call(name) || {}
+  end
+end
 
 if list_mode
-   dry_run = Hash.new
-   max_spell_name = 0
-   cast_list.each { |spell|
-      spell = fix_spell.call(spell)
-      max_spell_name = [ max_spell_name, spell.name.length ].max
-      target_info.keys.each { |name|
-         next unless spell.stackable?(:target => name)
-         next unless spell.available?(:target => name)
-         next unless spell.time_per(:target => name) > short_spell_time
-         next if (name == Char.name) and (spell.circlename == 'Bard') and spell.active?
-         target_info[name][spell.num.to_s] ||= 0
-         dry_run[name] ||= Hash.new
-         if target_info[name][spell.num.to_s] < start_at
-            while ( (target_info[name][spell.num.to_s] < stop_at) and (target_info[name][spell.num.to_s] + spell.time_per(:target => name)) < stop_before )
-               dry_run[name][spell.num.to_s] = dry_run[name][spell.num.to_s] + 1
-               target_info[name][spell.num.to_s] += spell.time_per(:target => name)
-            end
-         end
-      }
-   }
-   cast_list.each { |spell|
-      spell = fix_spell.call(spell)
-      target_info.keys.each { |name|
-         next unless spell.refreshable?(:target => name)
-         next unless spell.available?(:target => name)
-         next unless spell.time_per(:target => name) > short_spell_time
-         next if (name == Char.name) and (spell.circlename == 'Bard') and spell.active?
-         target_info[name][spell.num.to_s] ||= 0
-         if (target_info[name][spell.num.to_s] < refreshable_min)
-            dry_run[name][spell.num.to_s] = dry_run[name][spell.num.to_s] + 1
-         end
-      }
-   }
-   cast_list.each { |spell|
-      spell = fix_spell.call(spell)
-      target_info.keys.each { |name|
-         next if spell.stackable?(:target => name) or spell.refreshable?(:target => name)
-         next unless spell.available?(:target => name)
-         next unless spell.time_per(:target => name) > short_spell_time
-         next if (name == Char.name) and (spell.circlename == 'Bard') and spell.active?
-         target_info[name][spell.num.to_s] ||= 0
-         unless target_info[name][spell.num.to_s] > 0
-            dry_run[name][spell.num.to_s] = dry_run[name][spell.num.to_s] + 1
-         end
-      }
-   }
-   get_bonus_string = proc { |spell|
-      bonus_list = Array.new
-      bonus_list.push "#{'+' if spell.bolt_as > 0}#{spell.bolt_as} bAS" unless spell.bolt_as.zero?
-      bonus_list.push "#{'+' if spell.physical_as > 0}#{spell.physical_as} pAS" unless spell.physical_as.zero?
-      bonus_list.push "#{'+' if spell.bolt_ds > 0}#{spell.bolt_ds} bDS" unless spell.bolt_ds.zero?
-      bonus_list.push "#{'+' if spell.physical_ds > 0}#{spell.physical_ds} pDS" unless spell.physical_ds.zero?
-      bonus_list.push "#{'+' if spell.elemental_cs > 0}#{spell.elemental_cs} eCS" unless spell.elemental_cs.zero?
-      bonus_list.push "#{'+' if spell.spirit_cs > 0}#{spell.spirit_cs} spCS" unless spell.spirit_cs.zero?
-      bonus_list.push "#{'+' if spell.sorcerer_cs > 0}#{spell.sorcerer_cs} soCS" unless spell.sorcerer_cs.zero?
-      bonus_list.push "#{'+' if spell.elemental_td > 0}#{spell.elemental_td} eTD" unless spell.elemental_td.zero?
-      bonus_list.push "#{'+' if spell.spirit_td > 0}#{spell.spirit_td} spTD" unless spell.spirit_td.zero?
-      bonus_list.push "#{'+' if spell.sorcerer_td > 0}#{spell.sorcerer_td} soTD" unless spell.sorcerer_td.zero?
-      bonus_list.push "#{'+' if spell.strength.to_i > 0}#{spell.strength} str" unless spell.strength.to_i.zero?
-      bonus_list.push "#{'+' if spell.dodging.to_i > 0}#{spell.dodging} dodge" unless spell.dodging.to_i.zero?
-      bonus_list.join(', ')
-   }
-   total_casts = 0
-   total_mana  = 0
-   output = "\n"
-   for name,hash in dry_run
-      if hash.empty?
-         output.concat "#{name.capitalize}: no spells needed\n"
-      else
-         output.concat "#{(name.capitalize + ':').ljust(8+max_spell_name)}casts  mana  duration  bonus\n"
-         for spell,casts in hash
-            spell = Spell[spell]
-            total_casts += casts
-            total_mana += casts * spell.mana_cost
-            output.concat "#{spell.num.to_s.rjust(4)}  #{spell.name.ljust(max_spell_name)}  #{casts.to_s.rjust(5)}  #{(spell.mana_cost*casts).to_s.rjust(4)}   #{(spell.time_per(:target => name)*casts).as_time}  #{get_bonus_string.call(spell)}\n"
-         end
+  dry_run = {}
+  max_spell_name = 0
+  cast_list.each do |spell|
+    spell = fix_spell.call(spell)
+    max_spell_name = [max_spell_name, spell.name.length].max
+    target_info.keys.each do |name|
+      next unless spell.stackable?(target: name)
+      next unless spell.available?(target: name)
+      next unless spell.time_per(target: name) > short_spell_time
+      next if (name == Char.name) && (spell.circlename == 'Bard') && spell.active?
+
+      target_info[name][spell.num.to_s] ||= 0
+      dry_run[name] ||= {}
+      next unless target_info[name][spell.num.to_s] < start_at
+
+      while (target_info[name][spell.num.to_s] < stop_at) && ((target_info[name][spell.num.to_s] + spell.time_per(target: name)) < stop_before)
+        dry_run[name][spell.num.to_s] = dry_run[name][spell.num.to_s] + 1
+        target_info[name][spell.num.to_s] += spell.time_per(target: name)
       end
-      output.concat "\n"
-   end
-   output.concat "#{''.ljust(max_spell_name)}   total: #{total_casts.to_s.rjust(3)}  #{total_mana.to_s.rjust(4)}\n\n" unless total_casts.zero?
-   respond output
+    end
+  end
+  cast_list.each do |spell|
+    spell = fix_spell.call(spell)
+    target_info.keys.each do |name|
+      next unless spell.refreshable?(target: name)
+      next unless spell.available?(target: name)
+      next unless spell.time_per(target: name) > short_spell_time
+      next if (name == Char.name) && (spell.circlename == 'Bard') && spell.active?
+
+      target_info[name][spell.num.to_s] ||= 0
+      if target_info[name][spell.num.to_s] < refreshable_min
+        dry_run[name][spell.num.to_s] = dry_run[name][spell.num.to_s] + 1
+      end
+    end
+  end
+  cast_list.each do |spell|
+    spell = fix_spell.call(spell)
+    target_info.keys.each do |name|
+      next if spell.stackable?(target: name) || spell.refreshable?(target: name)
+      next unless spell.available?(target: name)
+      next unless spell.time_per(target: name) > short_spell_time
+      next if (name == Char.name) && (spell.circlename == 'Bard') && spell.active?
+
+      target_info[name][spell.num.to_s] ||= 0
+      dry_run[name][spell.num.to_s] = dry_run[name][spell.num.to_s] + 1 unless target_info[name][spell.num.to_s] > 0
+    end
+  end
+  get_bonus_string = proc { |spell|
+    bonus_list = []
+    bonus_list.push "#{'+' if spell.bolt_as > 0}#{spell.bolt_as} bAS" unless spell.bolt_as.zero?
+    bonus_list.push "#{'+' if spell.physical_as > 0}#{spell.physical_as} pAS" unless spell.physical_as.zero?
+    bonus_list.push "#{'+' if spell.bolt_ds > 0}#{spell.bolt_ds} bDS" unless spell.bolt_ds.zero?
+    bonus_list.push "#{'+' if spell.physical_ds > 0}#{spell.physical_ds} pDS" unless spell.physical_ds.zero?
+    bonus_list.push "#{'+' if spell.elemental_cs > 0}#{spell.elemental_cs} eCS" unless spell.elemental_cs.zero?
+    bonus_list.push "#{'+' if spell.spirit_cs > 0}#{spell.spirit_cs} spCS" unless spell.spirit_cs.zero?
+    bonus_list.push "#{'+' if spell.sorcerer_cs > 0}#{spell.sorcerer_cs} soCS" unless spell.sorcerer_cs.zero?
+    bonus_list.push "#{'+' if spell.elemental_td > 0}#{spell.elemental_td} eTD" unless spell.elemental_td.zero?
+    bonus_list.push "#{'+' if spell.spirit_td > 0}#{spell.spirit_td} spTD" unless spell.spirit_td.zero?
+    bonus_list.push "#{'+' if spell.sorcerer_td > 0}#{spell.sorcerer_td} soTD" unless spell.sorcerer_td.zero?
+    bonus_list.push "#{'+' if spell.strength.to_i > 0}#{spell.strength} str" unless spell.strength.to_i.zero?
+    bonus_list.push "#{'+' if spell.dodging.to_i > 0}#{spell.dodging} dodge" unless spell.dodging.to_i.zero?
+    bonus_list.join(', ')
+  }
+  total_casts = 0
+  total_mana  = 0
+  output = "\n"
+  dry_run.each do |name, hash|
+    if hash.empty?
+      output.concat "#{name.capitalize}: no spells needed\n"
+    else
+      output.concat "#{(name.capitalize + ':').ljust(8 + max_spell_name)}casts  mana  duration  bonus\n"
+      hash.each do |spell, casts|
+        spell = Spell[spell]
+        total_casts += casts
+        total_mana += casts * spell.mana_cost
+        output.concat "#{spell.num.to_s.rjust(4)}  #{spell.name.ljust(max_spell_name)}  #{casts.to_s.rjust(5)}  #{(spell.mana_cost * casts).to_s.rjust(4)}   #{(spell.time_per(target: name) * casts).as_time}  #{get_bonus_string.call(spell)}\n"
+      end
+    end
+    output.concat "\n"
+  end
+  unless total_casts.zero?
+    output.concat "#{''.ljust(max_spell_name)}   total: #{total_casts.to_s.rjust(3)}  #{total_mana.to_s.rjust(4)}\n\n"
+  end
+  respond output
 else
-   if cast_list.include?(625)
-      cast_list.delete(625)
-      cast_list.unshift(625)
-   end
-   skip_targets   = Array.new
-   skip_spells    = Array.new
-   did_first_cast = Hash.new
-   #
-   # cast stackable spells
-   #
-   loop {
-      did_cast = false
-      have_rapid = Spell[515].active?
-      cast_list.each { |spell|
-         if use_concentration and (sigil_of_concentration = Spell[9714])
-            sigil_of_concentration.cast if sigil_of_concentration.known? and sigil_of_concentration.affordable? and not sigil_of_concentration.active?
-         end
-         spell = fix_spell.call(spell)
-         target_info.keys.each { |name|
-            next unless spell.stackable?(:target => name)
-            next unless spell.available?(:target => name)
-            next unless spell.time_per(:target => name) > short_spell_time
-            next if skip_targets.include?(name) or skip_spells.include?(spell.num)
-            next if (name == Char.name) and (spell.circlename == 'Bard') and spell.active?
-            target_info[name][spell.num.to_s] ||= 0
-            did_first_cast[name] ||= Hash.new
-            if (target_info[name][spell.num.to_s] < start_at) or did_first_cast[name][spell.num.to_s]
-               did_first_cast[name][spell.num.to_s] = true
-               if use_multicast and spell.multicastable?
-                  multicast_num = 0
-                  need_chant = false
-                  dur = target_info[name][spell.num.to_s]
-                  while ( (dur < stop_at) and (dur + spell.time_per(:target => name)) < stop_before )
-                     dur += spell.time_per(:target => name)
-                     multicast_num += 1
-                     need_chant = true if (spell.num == 712) and (name == Char.name)
-                  end
-                  did_multicast = false
-                  (multicast_num / max_multicast.call(spell)).times {
-                     cast_result = cast_spell.call(spell, name, max_multicast.call(spell))
-                     target_info[name][spell.num.to_s] += (spell.time_per(:target => name) * max_multicast.call(spell))
-                     if cast_result == :bad_spell
-                        skip_spells.push(spell.num)
-                        break
-                     elsif cast_result == :bad_target
-                        skip_targets.push(name)
-                        break
-                     else
-                        did_cast = true
-                     end
-                     did_multicast = true
-                     break unless have_rapid
-                  }
-                  if have_rapid or not did_multicast
-                     unless ((multicast_num % max_multicast.call(spell)) < 1) or skip_targets.include?(name) or skip_spells.include?(spell.num)
-                        cast_result = cast_spell.call(spell, name, (multicast_num % max_multicast.call(spell)))
-                        target_info[name][spell.num.to_s] += (spell.time_per(:target => name) * (multicast_num % max_multicast.call(spell)))
-                        if cast_result == :bad_spell
-                           skip_spells.push(spell.num)
-                        elsif cast_result == :bad_target
-                           skip_targets.push(name)
-                        else
-                           did_cast = true
-                        end
-                     end
-                  end
-               else
-                  need_chant = false
-                  while ( (target_info[name][spell.num.to_s] < stop_at) and (target_info[name][spell.num.to_s] + spell.time_per(:target => name)) < stop_before )
-                     need_chant = true if (spell.num == 712) and (name == Char.name)
-                     empty_hand if spell.num == 203
-                     cast_result = cast_spell.call(spell, name, 1)
-                     if spell.num == 203
-                        if bread = [ GameObj.right_hand, GameObj.left_hand ].find { |obj| obj.noun =~ /^(?:flatbread|teacake|crisps|cake|waybread|biscuit|oatcake|fritter|loaf|ball|cornmeal|wheatberries|cracker|dumpling|bread|tart|dough|seeds)$/ }
-                           if name == Char.name
-                              5.times { fput "eat ##{bread.id}" }
-                           else
-                              fput "drop ##{bread.id}"
-                           end
-                        end
-                        fill_hand
-                        break
-                     end
-                     if cast_result == :bad_spell
-                        skip_spells.push(spell.num)
-                        break
-                     elsif cast_result == :bad_target
-                        skip_targets.push(name)
-                        break
-                     else
-                        did_cast = true
-                     end
-                     target_info[name][spell.num.to_s] += spell.time_per(:target => name)
-                     break unless have_rapid
-                  end
-               end
-               if need_chant and retribution_spell
-                  fput "chant retribution #{retribution_spell}"
-               end
-            end
-         }
-         release_spell.call
-      }
-      break unless did_cast
-      break if have_rapid
-   }
-
-   #
-   # cast refreshable spells
-   #
-   cast_list.each { |spell|
-      if use_concentration and (sigil_of_concentration = Spell[9714])
-         sigil_of_concentration.cast if sigil_of_concentration.known? and sigil_of_concentration.affordable? and not sigil_of_concentration.active?
+  if cast_list.include?(625)
+    cast_list.delete(625)
+    cast_list.unshift(625)
+  end
+  skip_targets   = []
+  skip_spells    = []
+  did_first_cast = {}
+  #
+  # cast stackable spells
+  #
+  loop do
+    did_cast = false
+    have_rapid = Spell[515].active?
+    cast_list.each do |spell|
+      if use_concentration && (sigil_of_concentration = Spell[9714])
+        if sigil_of_concentration.known? && sigil_of_concentration.affordable? && !sigil_of_concentration.active?
+          sigil_of_concentration.cast
+        end
       end
       spell = fix_spell.call(spell)
-      target_info.keys.each { |name|
-         next if spell.stackable?(:target => name)
-         next unless spell.available?(:target => name)
-         next unless spell.time_per(:target => name) > short_spell_time
-         next if skip_targets.include?(name) or skip_spells.include?(spell.num)
-         next if (name == Char.name) and (spell.circlename == 'Bard') and spell.active?
-         target_info[name][spell.num.to_s] ||= 0
-         if (target_info[name][spell.num.to_s] < refreshable_min)
-            cast_result = cast_spell.call(spell, name, 1)
-            if cast_result == :bad_spell
-               skip_spells.push(spell.num)
-               break
-            elsif cast_result == :bad_target
-               skip_targets.push(name)
-            end
-         end
-      }
-      release_spell.call
-   }
+      target_info.keys.each do |name|
+        next unless spell.stackable?(target: name)
+        next unless spell.available?(target: name)
+        next unless spell.time_per(target: name) > short_spell_time
+        next if skip_targets.include?(name) || skip_spells.include?(spell.num)
+        next if (name == Char.name) && (spell.circlename == 'Bard') && spell.active?
 
-   #
-   # cast solid-block spells
-   #
-   cast_list.each { |spell|
-      spell = fix_spell.call(spell)
-      target_info.keys.each { |name|
-         next if spell.stackable?(:target => name) or spell.refreshable?(:target => name)
-         next unless spell.available?(:target => name)
-         next unless spell.time_per(:target => name) > short_spell_time
-         next if (name == Char.name) and (spell.circlename == 'Bard') and spell.active?
-         target_info[name][spell.num.to_s] ||= 0
-         unless target_info[name][spell.num.to_s] > 0
-            cast_result = cast_spell.call(spell, name, 1)
-            if cast_result == :bad_spell
-               skip_spells.push(spell.num)
-               break
-            elsif cast_result == :bad_target
-               skip_targets.push(name)
-            end
-         end
-      }
-      release_spell.call
-   }
+        target_info[name][spell.num.to_s] ||= 0
+        did_first_cast[name] ||= {}
+        next unless (target_info[name][spell.num.to_s] < start_at) || did_first_cast[name][spell.num.to_s]
 
-   if did_something
-      echo 'done'
-   else
-      echo 'nothing to do'
-   end
+        did_first_cast[name][spell.num.to_s] = true
+        if use_multicast && spell.multicastable?
+          multicast_num = 0
+          need_chant = false
+          dur = target_info[name][spell.num.to_s]
+          while (dur < stop_at) && ((dur + spell.time_per(target: name)) < stop_before)
+            dur += spell.time_per(target: name)
+            multicast_num += 1
+            need_chant = true if (spell.num == 712) && (name == Char.name)
+          end
+          did_multicast = false
+          (multicast_num / max_multicast.call(spell)).times do
+            cast_result = cast_spell.call(spell, name, max_multicast.call(spell))
+            target_info[name][spell.num.to_s] += (spell.time_per(target: name) * max_multicast.call(spell))
+            if cast_result == :bad_spell
+              skip_spells.push(spell.num)
+              break
+            elsif cast_result == :bad_target
+              skip_targets.push(name)
+              break
+            else
+              did_cast = true
+            end
+            did_multicast = true
+            break unless have_rapid
+          end
+          if have_rapid || !did_multicast
+            unless ((multicast_num % max_multicast.call(spell)) < 1) || skip_targets.include?(name) || skip_spells.include?(spell.num)
+              cast_result = cast_spell.call(spell, name, (multicast_num % max_multicast.call(spell)))
+              target_info[name][spell.num.to_s] += (spell.time_per(target: name) * (multicast_num % max_multicast.call(spell)))
+              if cast_result == :bad_spell
+                skip_spells.push(spell.num)
+              elsif cast_result == :bad_target
+                skip_targets.push(name)
+              else
+                did_cast = true
+              end
+            end
+          end
+        else
+          need_chant = false
+          while (target_info[name][spell.num.to_s] < stop_at) && ((target_info[name][spell.num.to_s] + spell.time_per(target: name)) < stop_before)
+            need_chant = true if (spell.num == 712) && (name == Char.name)
+            empty_hand if spell.num == 203
+            cast_result = cast_spell.call(spell, name, 1)
+            if spell.num == 203
+              if bread = [GameObj.right_hand, GameObj.left_hand].find { |obj| obj.noun =~ /^(?:flatbread|teacake|crisps|cake|waybread|biscuit|oatcake|fritter|loaf|ball|cornmeal|wheatberries|cracker|dumpling|bread|tart|dough|seeds)$/ }
+                if name == Char.name
+                  5.times { fput "eat ##{bread.id}" }
+                else
+                  fput "drop ##{bread.id}"
+                end
+              end
+              fill_hand
+              break
+            end
+            if cast_result == :bad_spell
+              skip_spells.push(spell.num)
+              break
+            elsif cast_result == :bad_target
+              skip_targets.push(name)
+              break
+            else
+              did_cast = true
+            end
+            target_info[name][spell.num.to_s] += spell.time_per(target: name)
+            break unless have_rapid
+          end
+        end
+        fput "chant retribution #{retribution_spell}" if need_chant && retribution_spell
+      end
+      release_spell.call
+    end
+    break unless did_cast
+    break if have_rapid
+  end
+
+  #
+  # cast refreshable spells
+  #
+  cast_list.each do |spell|
+    if use_concentration && (sigil_of_concentration = Spell[9714])
+      if sigil_of_concentration.known? && sigil_of_concentration.affordable? && !sigil_of_concentration.active?
+        sigil_of_concentration.cast
+      end
+    end
+    spell = fix_spell.call(spell)
+    target_info.keys.each do |name|
+      next if spell.stackable?(target: name)
+      next unless spell.available?(target: name)
+      next unless spell.time_per(target: name) > short_spell_time
+      next if skip_targets.include?(name) || skip_spells.include?(spell.num)
+      next if (name == Char.name) && (spell.circlename == 'Bard') && spell.active?
+
+      target_info[name][spell.num.to_s] ||= 0
+      next unless target_info[name][spell.num.to_s] < refreshable_min
+
+      cast_result = cast_spell.call(spell, name, 1)
+      if cast_result == :bad_spell
+        skip_spells.push(spell.num)
+        break
+      elsif cast_result == :bad_target
+        skip_targets.push(name)
+      end
+    end
+    release_spell.call
+  end
+
+  #
+  # cast solid-block spells
+  #
+  cast_list.each do |spell|
+    spell = fix_spell.call(spell)
+    target_info.keys.each do |name|
+      next if spell.stackable?(target: name) || spell.refreshable?(target: name)
+      next unless spell.available?(target: name)
+      next unless spell.time_per(target: name) > short_spell_time
+      next if (name == Char.name) && (spell.circlename == 'Bard') && spell.active?
+
+      target_info[name][spell.num.to_s] ||= 0
+      next if target_info[name][spell.num.to_s] > 0
+
+      cast_result = cast_spell.call(spell, name, 1)
+      if cast_result == :bad_spell
+        skip_spells.push(spell.num)
+        break
+      elsif cast_result == :bad_target
+        skip_targets.push(name)
+      end
+    end
+    release_spell.call
+  end
+
+  if did_something
+    echo 'done'
+  else
+    echo 'nothing to do'
+  end
 end


### PR DESCRIPTION
This update creates a proc to check stamina for monks.

Modest corrections to the regex for spell detection using spell active <other> have been made.

In addition, this update corrects several GTK statements to remove console errors and warnings when setup is run.  The GUI has two modest changes - centering the labels for spells to cast and spells not to cast, and removing the pointless render.background statement forcing the listtree views to white.

The file has also been passed through rubocop for stylistic and format issues.  Thus, it appears as if nearly the entire file has changed.  Functionally with the exceptions noted above, it is functionally equivalent. 