### PR TITLE
Repair GTK3 error - class variable change to instance variable

### DIFF
--- a/scripts/auto-level2.lic
+++ b/scripts/auto-level2.lic
@@ -253,7 +253,7 @@ current_level = Char.level
 setup = proc{
   Gtk.queue {
     $auto_level_WINDOW = Gtk::Window.new
-    $auto_level_WINDOW.set_icon(@@default_icon)
+    $auto_level_WINDOW.set_icon(@default_icon)
     $auto_level_WINDOW.title = "auto_level"
     $auto_level_WINDOW.set_border_width(10)
     $auto_level_BOX = Gtk::Box.new(:vertical)

--- a/scripts/bardwag.lic
+++ b/scripts/bardwag.lic
@@ -328,7 +328,7 @@ elsif script.vars[1] =~ /^setup$|^options$/i
 			main_box.pack_start(button_box, :expand => false, :fill => false, :padding => 0)
 
 			window = Gtk::Window.new
-			window.set_icon(@@default_icon)
+			window.set_icon(@default_icon)
 			window.title = 'waggle setup'
 			window.border_width = 5
 			window.add(main_box)

--- a/scripts/betazzherb.lic
+++ b/scripts/betazzherb.lic
@@ -88,7 +88,7 @@ setup = proc {
 
     # Primary Window
     window = Gtk::Window.new
-  window.set_icon(@@default_icon)
+  window.set_icon(@default_icon)
     window.title = "Zzentar's Forgaging Script"
     window.border_width = 3
     window.resizable = false

--- a/scripts/mybounty.lic
+++ b/scripts/mybounty.lic
@@ -30,7 +30,7 @@ end
 setup = proc{
   Gtk.queue {
     $MB_WINDOW = Gtk::Window.new
-    $MB_WINDOW.set_icon(@@default_icon)
+    $MB_WINDOW.set_icon(@default_icon)
     $MB_WINDOW.title = "Mybounty Setup"
     $MB_WINDOW.set_border_width(10)
     $MB_BOX = Gtk::Box.new(:vertical)


### PR DESCRIPTION
Users reporting GTK3 blocking errors.  Issue is design change from class variable for default windows icon in Lich5 to instance variable.  Four scripts affected.  Four scripts modified.