### PR TITLE
Fixed default_icon and Ranger Spell

### DIFF
--- a/scripts/betazzherb.lic
+++ b/scripts/betazzherb.lic
@@ -88,7 +88,7 @@ setup = proc {
 
     # Primary Window
     window = Gtk::Window.new
-  window.set_icon(@@default_icon)
+  window.set_icon(@default_icon)
     window.title = "Zzentar's Forgaging Script"
     window.border_width = 3
     window.resizable = false
@@ -534,8 +534,8 @@ for herb_room in target_list
       Spell[506].cast   #Haste
     end
 
-    if Spell[603].known? and not Spell[603].active?
-      Spell[603].cast   #Foraging, +10 to roll
+    if Spell[604].known? and not Spell[604].active?
+      Spell[604].cast   #Foraging, +10 to roll
     end
 
     if Spell[1035].known? and not Spell[1035].active? and settings['sing_tonis']


### PR DESCRIPTION
This fixes the default_icon error and sets the correct ranger spell after the natures bounty change